### PR TITLE
Add C FFI for `gevulot-shim`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "gevulot-shim-ffi"
+version = "0.1.0"
+dependencies = [
+ "gevulot-shim",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ exclude = [
 members = [
   "crates/node",
   "crates/shim",
+  "crates/shim-ffi",
   "crates/tests/test-programs",
   "crates/tests/e2e-tests",
 ]

--- a/crates/shim-ffi/Cargo.toml
+++ b/crates/shim-ffi/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "gevulot-shim-ffi"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gevulot-shim = { path = "../shim" }

--- a/crates/shim-ffi/shim.h
+++ b/crates/shim-ffi/shim.h
@@ -1,0 +1,29 @@
+#ifndef SHIM_H
+#define SHIM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+
+/* Task type contains necessary parameters for executing the program. */
+typedef struct Task {
+  const char *id;
+  const char *const *args;
+  const char *const *files;
+} Task;
+
+/* new_task_result is a function to construct the task result type. It takes
+ * result data as a parameter, in case there is some. */
+void *new_task_result(uint8_t *data, size_t len);
+
+/* add_file_to_result allows adding persisted files to task result for
+ * returning back to Gevulot node. */
+void add_file_to_result(void *result, const char *file_name);
+
+/* run function is the entry point for Gevulot. It takes callback function
+ * pointer as a parameter and invokes it when there is task for execution.
+ * The callback function is then expected to return task result once it's
+ * finished. */
+void run(void *(*callback)(const struct Task*));
+
+#endif

--- a/crates/shim-ffi/src/lib.rs
+++ b/crates/shim-ffi/src/lib.rs
@@ -21,8 +21,11 @@ pub struct TaskResult {
     files: Vec<String>,
 }
 
+/// # Safety
+/// This function is safe as long as passed parameters `data` and `len` together
+///  are valid ((NULL, 0) are also valid).
 #[no_mangle]
-pub extern "C" fn new_task_result(data: *mut u8, len: usize) -> *mut TaskResult {
+pub unsafe extern "C" fn new_task_result(data: *mut u8, len: usize) -> *mut TaskResult {
     // SAFETY: 1. This is safe as long as passed `data` and `len` arguments are valid.
     unsafe {
         let data = if data.is_null() {
@@ -39,8 +42,10 @@ pub extern "C" fn new_task_result(data: *mut u8, len: usize) -> *mut TaskResult 
     }
 }
 
+/// # Safety
+/// This function is save as long as passed parameters are valid.
 #[no_mangle]
-pub extern "C" fn add_file_to_result(result: *mut TaskResult, file_name: *const c_char) {
+pub unsafe extern "C" fn add_file_to_result(result: *mut TaskResult, file_name: *const c_char) {
     // SAFETY: Following is only safe if the passed `file_name` is:
     // 1. valid pointer
     // 2. null terminated.

--- a/crates/shim-ffi/src/lib.rs
+++ b/crates/shim-ffi/src/lib.rs
@@ -1,0 +1,99 @@
+use std::ffi::{c_char, CStr, CString};
+
+#[repr(C)]
+pub struct Task {
+    id: *const c_char,
+    pub args: *const *const c_char,
+    pub files: *const *const c_char,
+}
+
+impl std::fmt::Debug for Task {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "id: {:#?}", self.id)?;
+        write!(f, "args: {:#?}", self.args)?;
+        write!(f, "files: {:#?}", self.files)
+    }
+}
+
+#[repr(C)]
+pub struct TaskResult {
+    data: Vec<u8>,
+    files: Vec<String>,
+}
+
+#[no_mangle]
+pub extern "C" fn new_task_result(data: *mut u8, len: usize) -> *mut TaskResult {
+    // SAFETY: 1. This is safe as long as passed `data` and `len` arguments are valid.
+    unsafe {
+        let data = if data.is_null() {
+            vec![]
+        } else {
+            let slice = std::slice::from_raw_parts(data, len);
+            slice.to_vec()
+        };
+
+        Box::into_raw(Box::new(TaskResult {
+            data,
+            files: vec![],
+        }))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn add_file_to_result(result: *mut TaskResult, file_name: *const c_char) {
+    // SAFETY: Following is only safe if the passed `file_name` is:
+    // 1. valid pointer
+    // 2. null terminated.
+    let c_str = unsafe { CStr::from_ptr(file_name) };
+
+    // SAFETY: `result` pointer dereferencing is safe because that pointer
+    // originates from this library (above).
+    unsafe {
+        (*result)
+            .files
+            .push(c_str.to_string_lossy().into_owned().clone());
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn run(callback: extern "C" fn(*const Task) -> *mut TaskResult) {
+    let res = gevulot_shim::run(|task: &gevulot_shim::Task| -> Result<gevulot_shim::TaskResult, Box<dyn std::error::Error>> {
+        let id_cstr = CString::new(task.id.clone()).expect("task.id");
+
+        // Convert Vec<String> -> *const *const c_char.
+        let cstr_args: Vec<CString> = task.args.iter().map(|s| CString::new(s.as_str()).expect("task.arg")).collect();
+        let cstr_files: Vec<CString> = task.files.iter().map(|s| CString::new(s.as_str()).expect("task.file")).collect();
+
+        let mut carr_args: Vec<*const c_char> = cstr_args.iter().map(|s| s.as_ptr()).collect();
+        let mut carr_files: Vec<*const c_char> = cstr_files.iter().map(|s| s.as_ptr()).collect();
+
+        // Terminate the arrays.
+        carr_args.push(std::ptr::null());
+        carr_files.push(std::ptr::null());
+
+        let c_task = Task{
+            id: id_cstr.as_ptr(),
+            args: carr_args.as_ptr(),
+            files: carr_files.as_ptr(),
+        };
+
+        let result = callback(&c_task);
+
+        let data;
+        let files;
+
+        // SAFETY: Given that pointer of `result` is valid, the internals of 
+        // TaskResult are handled within this library and are therefore
+        // expected to be safe.
+        unsafe {
+            files = (*result).files.clone();
+            data = (*result).data.clone();
+        }
+
+        task.result(data, files)
+    });
+
+    if res.is_err() {
+        eprintln!("error: {:#?}", res.unwrap())
+    }
+}

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -25,7 +25,7 @@ pub type TaskId = String;
 
 #[derive(Debug)]
 pub struct Task {
-    id: TaskId,
+    pub id: TaskId,
     pub args: Vec<String>,
     pub files: Vec<String>,
 }
@@ -233,7 +233,7 @@ fn mount_present(mount_point: &str) -> Result<bool> {
 
 /// run function takes `callback` that is invoked with executable `Task` and
 /// which is expected to return `TaskResult`.
-pub fn run(callback: fn(&Task) -> Result<TaskResult>) -> Result<()> {
+pub fn run(callback: impl Fn(&Task) -> Result<TaskResult>) -> Result<()> {
     let mut client = GRPCClient::new(8080, "/workspace")?;
 
     loop {


### PR DESCRIPTION
In order to have ability to use shim with non-Rust provers, a C FFI is needed for `gevulot-shim`. This commit provides the first version of that.