### PR TITLE
Add command for DB migration

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -156,6 +156,17 @@ pub enum Command {
         target: GenerateCommand,
     },
 
+    /// Migrate DB.
+    Migrate {
+        #[arg(
+            long,
+            long_help = "Database URL",
+            env = "GEVULOT_DB_URL",
+            default_value = "postgres://gevulot:gevulot@localhost/gevulot"
+        )]
+        db_url: String,
+    },
+
     /// Peer related commands.
     Peer {
         peer: String,


### PR DESCRIPTION
In order to have a simple mechanism for running DB migrations, add `migrate` command. This way the node operator doesn't need to install `sqlx-cli` cargo plugin in order to migrate the DB.