### PR TITLE
Restrict `proofs` table with UNIQUE(parent, prover)

### DIFF
--- a/crates/node/migrations/20231128120351_transactions-table.sql
+++ b/crates/node/migrations/20231128120351_transactions-table.sql
@@ -79,6 +79,7 @@ CREATE TABLE proof (
     parent VARCHAR(64) NOT NULL,
     prover VARCHAR(64),
     proof BYTEA NOT NULL,
+    UNIQUE(parent, prover),
     CONSTRAINT fk_transaction1
         FOREIGN KEY (tx)
             REFERENCES transaction (hash) ON DELETE CASCADE,


### PR DESCRIPTION
Currently `Program`s are unique within `Workflow` and therefore it's impossible to have same `parent` and `prover` hashes for multiple proofs.