### PR TITLE
Add transaction validation

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -123,15 +123,12 @@ pub async fn run_exec_command(
         .map(|t| t.try_into())
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut tx = Transaction {
-        payload: Payload::Run {
+    let tx = Transaction::new(
+        Payload::Run {
             workflow: Workflow { steps },
         },
-        // NOTE: In the devnet `nonce` is just a placeholder for the future.
-        nonce: 42,
-        ..Default::default()
-    };
-    tx.sign(&key);
+        &key,
+    );
 
     client.send_transaction(&tx).await?;
     Ok(tx.hash.to_string())
@@ -204,18 +201,14 @@ pub async fn run_deploy_command(
     let prover_hash = prover_data.hash.to_string();
     let verifier_hash = verifier_data.hash.to_string();
 
-    let mut tx = Transaction {
-        payload: Payload::Deploy {
+    let tx = Transaction::new(
+        Payload::Deploy {
             name,
             prover: prover_data,
             verifier: verifier_data,
         },
-        nonce: 42,
-        ..Default::default()
-    };
-
-    // Transaction hash gets computed during this as well.
-    tx.sign(&key);
+        &key,
+    );
 
     client
         .send_transaction(&tx)

--- a/crates/node/src/mempool/mod.rs
+++ b/crates/node/src/mempool/mod.rs
@@ -51,6 +51,9 @@ impl Mempool {
     }
 
     pub async fn add(&mut self, tx: Transaction) -> Result<()> {
+        // First validate transaction.
+        tx.validate()?;
+
         let mut tx = tx;
         self.storage.set(&tx).await?;
 

--- a/crates/node/src/networking/p2p.rs
+++ b/crates/node/src/networking/p2p.rs
@@ -151,9 +151,9 @@ impl Writing for P2P {
 mod tests {
     use super::*;
     use eyre::Result;
-    use gevulot_node::types::{transaction::Payload, Hash, Transaction};
+    use gevulot_node::types::{transaction::Payload, Transaction};
     use libsecp256k1::SecretKey;
-    use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, SeedableRng};
     use tokio::sync::mpsc::{self, Sender};
     use tracing::level_filters::LevelFilter;
     use tracing_subscriber::EnvFilter;
@@ -222,16 +222,8 @@ mod tests {
 
     fn new_tx() -> Transaction {
         let rng = &mut StdRng::from_entropy();
-        let mut tx = Transaction {
-            hash: Hash::random(rng),
-            payload: Payload::Empty,
-            nonce: rng.next_u64(),
-            ..Default::default()
-        };
-
         let key = SecretKey::random(rng);
-        tx.sign(&key);
-        tx
+        Transaction::new(Payload::Empty, &key)
     }
 
     fn start_logger(default_level: LevelFilter) {

--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -305,6 +305,7 @@ impl TaskManager for Scheduler {
                     nonce,
                     signature: Signature::default(),
                     propagated: false,
+                    rec_id: 0,
                 },
                 TaskKind::Verification => Transaction {
                     hash: Hash::default(),
@@ -316,6 +317,7 @@ impl TaskManager for Scheduler {
                     nonce,
                     signature: Signature::default(),
                     propagated: false,
+                    rec_id: 0,
                 },
                 TaskKind::PoW => {
                     todo!("proof of work tasks not implemented yet");

--- a/crates/node/src/storage/database/entity/mod.rs
+++ b/crates/node/src/storage/database/entity/mod.rs
@@ -1,4 +1,6 @@
 pub mod payload;
+pub mod public_key;
 pub mod transaction;
 
+pub use public_key::PublicKey;
 pub use transaction::Transaction;

--- a/crates/node/src/storage/database/entity/public_key.rs
+++ b/crates/node/src/storage/database/entity/public_key.rs
@@ -1,0 +1,89 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Decode, Encode, Postgres, Type};
+use thiserror::Error;
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Error, Debug)]
+pub enum PublicKeyError {
+    #[error("public key parse error: {0}")]
+    ParseError(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PublicKey(pub libsecp256k1::PublicKey);
+
+impl Default for PublicKey {
+    fn default() -> Self {
+        PublicKey(libsecp256k1::PublicKey::from_secret_key(
+            &libsecp256k1::SecretKey::default(),
+        ))
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0.serialize()))
+    }
+}
+impl From<PublicKey> for libsecp256k1::PublicKey {
+    fn from(value: PublicKey) -> Self {
+        value.0
+    }
+}
+
+impl From<String> for PublicKey {
+    fn from(value: String) -> Self {
+        Self::try_from(value.as_str()).expect("from string")
+    }
+}
+
+impl TryFrom<&str> for PublicKey {
+    type Error = PublicKeyError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let bs = hex::decode(value).map_err(|e| PublicKeyError::ParseError(e.to_string()))?;
+        let bs: [u8; 65] = bs
+            .try_into()
+            .map_err(|_| PublicKeyError::ParseError("byte array length".to_string()))?;
+        let pub_key = libsecp256k1::PublicKey::parse(&bs)
+            .map_err(|e| PublicKeyError::ParseError(e.to_string()))?;
+        Ok(PublicKey(pub_key))
+    }
+}
+
+impl PublicKey {
+    pub fn from_secret_key(secret_key: &libsecp256k1::SecretKey) -> PublicKey {
+        PublicKey(libsecp256k1::PublicKey::from_secret_key(&secret_key))
+    }
+}
+
+impl<'q> Decode<'q, Postgres> for PublicKey {
+    fn decode(
+        value: <Postgres as sqlx::database::HasValueRef<'q>>::ValueRef,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let str_value = <String as Decode<Postgres>>::decode(value)?;
+        Ok(PublicKey::from(str_value))
+    }
+}
+
+impl<'q> Encode<'q, Postgres> for PublicKey {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Postgres as sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+    ) -> sqlx::encode::IsNull {
+        let str_value = self.to_string();
+        <String as Encode<Postgres>>::encode(str_value, buf)
+    }
+}
+
+impl Type<Postgres> for PublicKey {
+    fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+        <String as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &<Postgres as sqlx::Database>::TypeInfo) -> bool {
+        <String as Type<Postgres>>::compatible(ty)
+    }
+}

--- a/crates/node/src/storage/database/entity/public_key.rs
+++ b/crates/node/src/storage/database/entity/public_key.rs
@@ -55,7 +55,7 @@ impl TryFrom<&str> for PublicKey {
 
 impl PublicKey {
     pub fn from_secret_key(secret_key: &libsecp256k1::SecretKey) -> PublicKey {
-        PublicKey(libsecp256k1::PublicKey::from_secret_key(&secret_key))
+        PublicKey(libsecp256k1::PublicKey::from_secret_key(secret_key))
     }
 }
 

--- a/crates/node/src/storage/database/entity/transaction.rs
+++ b/crates/node/src/storage/database/entity/transaction.rs
@@ -24,6 +24,7 @@ pub struct Transaction {
     pub nonce: sqlx::types::Decimal,
     pub signature: Signature,
     pub propagated: bool,
+    pub rec_id: i8,
 }
 
 impl From<&types::Transaction> for Transaction {
@@ -47,6 +48,8 @@ impl From<&types::Transaction> for Transaction {
             nonce: value.nonce.into(),
             signature: value.signature,
             propagated: value.propagated,
+            // This is safe because rec_id has values between 0-3.
+            rec_id: value.rec_id as i8,
         }
     }
 }
@@ -61,6 +64,8 @@ impl From<Transaction> for types::Transaction {
                 .expect("invalid nonce in db"),
             signature: value.signature,
             propagated: value.propagated,
+            // This is safe because rec_id has values between 0-3.
+            rec_id: value.rec_id as u8,
         }
     }
 }

--- a/crates/node/src/storage/database/postgres.rs
+++ b/crates/node/src/storage/database/postgres.rs
@@ -508,6 +508,8 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use libsecp256k1::{PublicKey, SecretKey};
+
     use crate::types::{
         transaction::{Payload, ProgramMetadata},
         Signature, Transaction,
@@ -523,6 +525,7 @@ mod tests {
             .expect("failed to connect to db");
 
         let tx = Transaction {
+            author: PublicKey::from_secret_key(&SecretKey::default()),
             hash: Hash::default(),
             payload: Payload::Deploy {
                 name: "test deployment".to_string(),
@@ -554,7 +557,6 @@ mod tests {
             nonce: 64,
             signature: Signature::default(),
             propagated: false,
-            rec_id: 0,
         };
 
         database

--- a/crates/node/src/storage/database/postgres.rs
+++ b/crates/node/src/storage/database/postgres.rs
@@ -554,6 +554,7 @@ mod tests {
             nonce: 64,
             signature: Signature::default(),
             propagated: false,
+            rec_id: 0,
         };
 
         database

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -269,7 +269,7 @@ impl Transaction {
             propagated: false,
         };
 
-        tx.sign(&signing_key);
+        tx.sign(signing_key);
 
         tx
     }

--- a/crates/node/src/workflow/mod.rs
+++ b/crates/node/src/workflow/mod.rs
@@ -328,7 +328,7 @@ mod tests {
 
     use gevulot_node::types::{
         transaction::{Payload, ProgramData, Workflow, WorkflowStep},
-        Hash, Signature, TaskKind, Transaction,
+        Hash, TaskKind, Transaction,
     };
     use libsecp256k1::SecretKey;
     use rand::{rngs::StdRng, SeedableRng};
@@ -444,74 +444,53 @@ mod tests {
 
     fn transaction_for_workflow_steps(steps: Vec<WorkflowStep>) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let mut tx = Transaction {
-            hash: Hash::default(),
-            payload: Payload::Run {
+        let tx = Transaction::new(
+            Payload::Run {
                 workflow: Workflow { steps },
             },
-            nonce: 1,
-            signature: Signature::default(),
-            propagated: false,
-            rec_id: 0,
-        };
-
-        tx.sign(&key);
+            &key,
+        );
         tx
     }
 
     fn transaction_for_proof(parent: &Hash, program: &Hash) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let mut tx = Transaction {
-            hash: Hash::default(),
-            payload: Payload::Proof {
+        let tx = Transaction::new(
+            Payload::Proof {
                 parent: *parent,
                 prover: *program,
                 proof: "proof.".into(),
             },
-            nonce: 1,
-            signature: Signature::default(),
-            propagated: false,
-            rec_id: 0,
-        };
+            &key,
+        );
 
-        tx.sign(&key);
         tx
     }
 
     fn transaction_for_proofkey(parent: &Hash) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let mut tx = Transaction {
-            hash: Hash::default(),
-            payload: Payload::ProofKey {
+        let tx = Transaction::new(
+            Payload::ProofKey {
                 parent: *parent,
                 key: "key.".into(),
             },
-            nonce: 1,
-            signature: Signature::default(),
-            propagated: false,
-            rec_id: 0,
-        };
+            &key,
+        );
 
-        tx.sign(&key);
         tx
     }
 
     fn transaction_for_verification(parent: &Hash, program: &Hash) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let mut tx = Transaction {
-            hash: Hash::default(),
-            payload: Payload::Verification {
+        let tx = Transaction::new(
+            Payload::Verification {
                 parent: *parent,
                 verifier: *program,
                 verification: b"verification.".to_vec(),
             },
-            nonce: 1,
-            signature: Signature::default(),
-            propagated: false,
-            rec_id: 0,
-        };
+            &key,
+        );
 
-        tx.sign(&key);
         tx
     }
 }

--- a/crates/node/src/workflow/mod.rs
+++ b/crates/node/src/workflow/mod.rs
@@ -452,6 +452,7 @@ mod tests {
             nonce: 1,
             signature: Signature::default(),
             propagated: false,
+            rec_id: 0,
         };
 
         tx.sign(&key);
@@ -470,6 +471,7 @@ mod tests {
             nonce: 1,
             signature: Signature::default(),
             propagated: false,
+            rec_id: 0,
         };
 
         tx.sign(&key);
@@ -487,6 +489,7 @@ mod tests {
             nonce: 1,
             signature: Signature::default(),
             propagated: false,
+            rec_id: 0,
         };
 
         tx.sign(&key);
@@ -505,6 +508,7 @@ mod tests {
             nonce: 1,
             signature: Signature::default(),
             propagated: false,
+            rec_id: 0,
         };
 
         tx.sign(&key);

--- a/crates/node/src/workflow/mod.rs
+++ b/crates/node/src/workflow/mod.rs
@@ -444,53 +444,46 @@ mod tests {
 
     fn transaction_for_workflow_steps(steps: Vec<WorkflowStep>) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let tx = Transaction::new(
+        Transaction::new(
             Payload::Run {
                 workflow: Workflow { steps },
             },
             &key,
-        );
-        tx
+        )
     }
 
     fn transaction_for_proof(parent: &Hash, program: &Hash) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let tx = Transaction::new(
+        Transaction::new(
             Payload::Proof {
                 parent: *parent,
                 prover: *program,
                 proof: "proof.".into(),
             },
             &key,
-        );
-
-        tx
+        )
     }
 
     fn transaction_for_proofkey(parent: &Hash) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let tx = Transaction::new(
+        Transaction::new(
             Payload::ProofKey {
                 parent: *parent,
                 key: "key.".into(),
             },
             &key,
-        );
-
-        tx
+        )
     }
 
     fn transaction_for_verification(parent: &Hash, program: &Hash) -> Transaction {
         let key = SecretKey::random(&mut StdRng::from_entropy());
-        let tx = Transaction::new(
+        Transaction::new(
             Payload::Verification {
                 parent: *parent,
                 verifier: *program,
                 verification: b"verification.".to_vec(),
             },
             &key,
-        );
-
-        tx
+        )
     }
 }


### PR DESCRIPTION
This is the first step towards having validation for transactions.

It verifies that transaction signature is correct and that current workflow restrictions are checked.

The transaction is validated on entering mempool, which covers currently all the key use cases in the program.