### PR TITLE
Add `Containerfile` to build node container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,18 @@
+FROM fedora:39
+
+# Install QEMU
+RUN dnf install -y qemu-kvm qemu-img
+
+# Install Ops.
+RUN /bin/curl -Lo /bin/ops https://storage.googleapis.com/cli/linux/ops && chmod 755 /bin/ops && /bin/ops update
+
+# Add Gevulot node bin.
+ADD target/release/gevulot /gevulot
+
+ADD crates/node/migrations /migrations
+
+RUN mkdir -p /var/lib/gevulot
+RUN /gevulot generate node-key
+
+CMD ["run"]
+ENTRYPOINT ["/gevulot"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,15 +1,29 @@
-FROM fedora:39
+FROM rust:1-bookworm
 
-# Install QEMU
-RUN dnf install -y qemu-kvm qemu-img
+COPY ./Cargo.* ./
+COPY ./crates ./crates
+
+RUN apt-get update && apt-get install -y \
+  libssl-dev \
+  protobuf-compiler
+
+RUN cargo build --release
+
+FROM debian:bookworm
+
+# Copy Gevulot node bin from earlier build step.
+COPY --from=0 target/release/gevulot /gevulot
+
+# Install QEMU.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  qemu-system
 
 # Install Ops.
 RUN /bin/curl -Lo /bin/ops https://storage.googleapis.com/cli/linux/ops && chmod 755 /bin/ops && /bin/ops update
 
-# Add Gevulot node bin.
-ADD target/release/gevulot /gevulot
-
-ADD crates/node/migrations /migrations
+COPY ./crates/node/migrations /migrations
 
 RUN mkdir -p /var/lib/gevulot
 RUN /gevulot generate node-key


### PR DESCRIPTION
The first version is based on Debian, but that choice shall be revisited later to optimize the container size.