### PR TITLE
Add P2P beacon mode

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -136,6 +136,25 @@ pub enum PeerCommand {
     },
 }
 
+#[derive(Debug, Args)]
+pub struct P2PBeaconConfig {
+    #[arg(
+        long,
+        long_help = "P2P listen address",
+        env = "GEVULOT_P2P_LISTEN_ADDR",
+        default_value = "127.0.0.1:9999"
+    )]
+    pub p2p_listen_addr: SocketAddr,
+
+    #[arg(
+        long,
+        long_help = "P2P PSK passphrase",
+        env = "GEVULOT_PSK_PASSPHRASE",
+        default_value = "Pack my box with five dozen liquor jugs."
+    )]
+    pub p2p_psk_passphrase: String,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum GenerateCommand {
     NodeKey {
@@ -182,6 +201,12 @@ pub enum Command {
 
         #[command(subcommand)]
         op: PeerCommand,
+    },
+
+    /// P2PBeacon is a run mode where only P2P code is executed. Used for coordinating other nodes in the network.
+    P2PBeacon {
+        #[command(flatten)]
+        config: P2PBeaconConfig,
     },
 
     /// Run the node.

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -48,7 +48,7 @@ pub struct Config {
         long,
         long_help = "",
         env = "GEVULOT_P2P_DISCOVERY_ADDR",
-        default_value = "bootstrap.p2p.devnet.gevulot.com"
+        default_value = "34.88.251.176:9999"
     )]
     pub p2p_discovery_addrs: Vec<String>,
 


### PR DESCRIPTION
P2P beacon mode allows for lightweight node instance to run, with only purpose to coordinate other nodes' peer discovery. This is effectively a special node in the network that bridges others.