### PR TITLE
Store workspace volumes in Gevulot data directory

### DIFF
--- a/crates/node/src/nanos/volume.rs
+++ b/crates/node/src/nanos/volume.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, process::Command};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use eyre::Result;
 use thiserror::Error;
@@ -13,8 +16,9 @@ pub enum NanosVolumeError {
     ParseError(String),
 }
 
-pub fn create(label: &str, size: &str) -> Result<PathBuf> {
+pub fn create(data_dir: &Path, label: &str, size: &str) -> Result<PathBuf> {
     let output = Command::new("ops")
+        .env("HOME", data_dir)
         .arg("volume")
         .arg("create")
         .arg(label)

--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -155,8 +155,12 @@ impl Provider for Qemu {
             .to_lowercase();
 
         // XXX: This isn't async and will call out to `ops` for now.
-        let workspace_file = nanos::volume::create(&workspace_volume_label, "2g")?.into_os_string();
+        tracing::debug!("creating workspace volume for the VM");
+        let workspace_file =
+            nanos::volume::create(&self.config.data_directory, &workspace_volume_label, "2g")?
+                .into_os_string();
         let workspace_file = workspace_file.to_str().expect("workspace volume path");
+        tracing::debug!("workspace volume created");
 
         let cpus = req.cpus;
         let mem_req = req.mem;


### PR DESCRIPTION
When running Gevulot node in container, the workspace volume creation fails if Ops hasn't been tricked to write the data into right place.

It doesn't allow direct configuration of images directory, but by adjusting $HOME, it can be tricked to save images in `/var/lib/gevulot/.ops/images`, which is fine for ephemeral workspace volumes.