### PR TITLE
Fix returned workspace volume path

### DIFF
--- a/crates/node/src/nanos/volume.rs
+++ b/crates/node/src/nanos/volume.rs
@@ -34,7 +34,7 @@ pub fn create(data_dir: &Path, label: &str, size: &str) -> Result<PathBuf> {
 
     let volume_file = parse_output(&String::from_utf8(output.stderr)?)?;
     Ok(PathBuf::new()
-        .join(home::home_dir().expect("missing $HOME"))
+        .join(data_dir)
         .join(".ops")
         .join("volumes")
         .join(volume_file))


### PR DESCRIPTION
The current implementation to manage workspace volumes is not very ideal for multiple reasons:
- Outsourcing the job to external Go program is not very efficient.
- We lack substantial amount of control over the volume details.
  - ...which leads to current state that it's horrible fragile hack in many ways.

I have started writing the Rust implementation of TFS, but it's half-way and there are several dragons due to fact that there's no documentation and it's fully written based on the existing Go code.