### PR TITLE
Improve help text for http port CLI flag

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -64,7 +64,7 @@ pub struct Config {
 
     #[arg(
         long,
-        long_help = "Port open to download file between nodes. Use P2P interface to bind.",
+        long_help = "Port open to download transaction data between nodes. Use P2P interface to bind.",
         env = "GEVULOT_HTTP_PORT",
         default_value = "9995"
     )]


### PR DESCRIPTION
Improve help text wording to give the right impression for a person who doesn't know internals of Gevulot node.