### PR TITLE
Fix INSERT SQL

### DIFF
--- a/crates/node/src/storage/database/postgres.rs
+++ b/crates/node/src/storage/database/postgres.rs
@@ -446,7 +446,7 @@ impl Database {
                                 checksum,
                             } => {
                                 sqlx::query(
-                                    "INSERT INTO program_input_data ( workflow_step_id, file_name, file_url, checksum ) VALUES ( $1, $2, $3, $4 ) ON CONFLICT (workflow_step_id) DO NOTHING")
+                                    "INSERT INTO program_input_data ( workflow_step_id, file_name, file_url, checksum ) VALUES ( $1, $2, $3, $4 ) ON CONFLICT (workflow_step_id, file_name) DO NOTHING")
                                     .bind(step_id)
                                     .bind(file_name)
                                     .bind(file_url)


### PR DESCRIPTION
The `program_input_data` has primary key that consists of (workflow_step_id, file_name). Therefore the `file_name` must also be present in ON CONFLICT clause.