### PR TITLE
Use std::process::exit(1) instead of panic

### DIFF
--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -282,7 +282,8 @@ impl Provider for Qemu {
                 if retry_count > 100 {
                     // If we can't start QEMU, there's no point running the node
                     // and the best way to capture operator's attention is to panic.
-                    panic!("failed to start QEMU; aborting.");
+                    tracing::error!("failed to start QEMU; aborting.");
+                    std::process::exit(1);
                 }
 
                 match Qmp::new(format!("localhost:{qmp_port}")).await {


### PR DESCRIPTION
When "everything" is async and running under the async runtime's thread pool, `panic!()` will not _actually_ panic, but instead just crash one thread in the async runtime. This is not the desired behaviour so use explicit process exit.