### PR TITLE
Fix QEMU params

### DIFF
--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -214,9 +214,6 @@ impl Provider for Qemu {
             .args(["-m", &format!("{mem_req}M")])
             .args(["-device", "virtio-rng-pci"])
             .args(["-machine", "accel=kvm:tcg"])
-            .args(["-cpu", "host"])
-            .arg("-no-reboot")
-            .arg("-no-shutdown")
             .args(["-cpu", "max"])
             // IMAGE FILE
             .args([


### PR DESCRIPTION
Cleanup & fix QEMU params:
- `-cpu host` is mostly overlapping with `-cpu max` which is correct.
- `-no-reboot` prevents program VM from correctly starting.
- `-no-shutdown` has no effect in our use case.