### PR TITLE
Include `author` field in `Transaction.hash`

### DIFF
--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -295,6 +295,7 @@ impl Transaction {
     pub fn compute_hash(&self) -> Hash {
         let mut hasher = Sha3_256::new();
         let mut buf = vec![];
+        hasher.update(self.author.serialize());
         self.payload.serialize_into(&mut buf);
         hasher.update(buf);
         hasher.update(self.nonce.to_be_bytes());


### PR DESCRIPTION
Transaction author's public key was added afterwards into `Transaction` struct, but forgotten from hash computation. This change includes it as well.