### PR TITLE
Add implementation to fetch transaction tree

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -176,7 +176,7 @@ fn print_tx_tree(tree: &TransactionTree, indentation: u16) {
             println!("Root: {hash}");
             children
                 .iter()
-                .for_each(|x| print_tx_tree(&x, indentation + 1));
+                .for_each(|x| print_tx_tree(x, indentation + 1));
         }
         TransactionTree::Node { children, hash } => {
             println!(
@@ -185,7 +185,7 @@ fn print_tx_tree(tree: &TransactionTree, indentation: u16) {
             );
             children
                 .iter()
-                .for_each(|x| print_tx_tree(&x, indentation + 1));
+                .for_each(|x| print_tx_tree(x, indentation + 1));
         }
         TransactionTree::Leaf { hash } => {
             println!(

--- a/crates/node/migrations/20240202122917_drop_unique_proof_parent_prover_constraint.sql
+++ b/crates/node/migrations/20240202122917_drop_unique_proof_parent_prover_constraint.sql
@@ -1,0 +1,5 @@
+
+-- Drop unique (parent, prover) constraint. Multiple nodes will generate proof
+-- for same Run transaction, using same prover program so this constraint is
+-- wrong.
+ALTER TABLE proof DROP CONSTRAINT proof_parent_prover_key;

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, rc::Rc};
 
 use super::hash::Hash;
 use super::signature::Signature;
@@ -12,16 +12,14 @@ use thiserror::Error;
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub enum TransactionTree {
     Root {
-        children: Vec<Arc<TransactionTree>>,
+        children: Vec<Rc<TransactionTree>>,
         hash: Hash,
     },
     Node {
-        parent: Arc<TransactionTree>,
-        children: Vec<Arc<TransactionTree>>,
+        children: Vec<Rc<TransactionTree>>,
         hash: Hash,
     },
     Leaf {
-        parent: Arc<TransactionTree>,
         hash: Hash,
     },
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
When working with `Run` transactions, it's useful to be able to fetch the whole transaction tree involved with the execution so far.