### PR TITLE
Ensure path exists under `/workspace`

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -181,6 +181,13 @@ impl GRPCClient {
             Err(e) => panic!("failed to construct path for a file to write: {:?}", e),
         };
 
+        // Ensure any necessary subdirectories exists.
+        if let Some(parent) = Path::new(&path).parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .expect("task file mkdir");
+        }
+
         let mut stream = self
             .client
             .lock()


### PR DESCRIPTION
When downloading files to program VM, ensure that the configured destination path exists.