### PR TITLE
Refactor task result files to streaming transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ name = "gevulot-shim"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "prost 0.11.9",
  "tokio",
  "tokio-stream",

--- a/crates/node/src/storage/file.rs
+++ b/crates/node/src/storage/file.rs
@@ -13,6 +13,10 @@ impl File {
         }
     }
 
+    pub fn data_dir(&self) -> PathBuf {
+        self.data_dir.clone()
+    }
+
     pub async fn get_task_file(
         &self,
         task_id: &str,

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+async-stream = "0.3.5"
 prost = "0.11"
 tokio = { version = "1.0", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-stream = "0.1"

--- a/crates/shim/proto/vm_service.proto
+++ b/crates/shim/proto/vm_service.proto
@@ -4,9 +4,15 @@ package vm_service;
 
 service VMService {
   rpc GetTask (TaskRequest) returns (TaskResponse) {}
-  rpc GetFile (FileRequest) returns (stream FileResponse) {}
+  rpc GetFile (GetFileRequest) returns (stream FileData) {}
 
+  rpc SubmitFile(stream FileData) returns (GenericResponse) {}
   rpc SubmitResult(TaskResultRequest) returns (TaskResultResponse) {}
+}
+
+message GenericResponse {
+  bool success = 1;
+  string message = 2;
 }
 
 message TaskRequest {}
@@ -30,14 +36,14 @@ message TaskResponse {
   }
 }
 
-message FileRequest {
+message GetFileRequest {
   string task_id = 1;
   string path = 2;
 }
 
-message File {
-  string path = 1;
-  bytes data = 2;
+message FileMetadata {
+  string task_id = 1;
+  string path = 2;
 }
 
 message FileChunk {
@@ -48,17 +54,18 @@ enum FileError {
   NotFound = 0;
 }
 
-message FileResponse {
+message FileData {
   oneof result {
-    FileChunk chunk = 1;
-    FileError error = 2;
+    FileMetadata metadata = 1;
+    FileChunk chunk = 2;
+    FileError error = 3;
   }
 }
 
 message TaskResult {
   string id = 1;
   bytes data = 2;
-  repeated File files = 3;
+  repeated string files = 3;
 }
 
 message TaskResultRequest {


### PR DESCRIPTION
Originally files resulting from program execution were embedded in `TaskResult` struct (with data & everything). With larger files this is problematic in many ways.

This commit refactors the result file transfer to take place one-by-one in streaming fashion. Now the `shim` will call `submit_file` for each file present in `TaskResult` and submit them before submitting the task result itself.

On server side, the file data is directly streamed into file.