### PR TITLE
Increase DB connect timeout from 750ms to 30s

### DIFF
--- a/crates/node/src/storage/database/postgres.rs
+++ b/crates/node/src/storage/database/postgres.rs
@@ -9,7 +9,7 @@ use super::entity::{self};
 use crate::types::{self, transaction::ProgramData, File, Hash, Program, Task};
 
 const MAX_DB_CONNS: u32 = 64;
-const DB_CONNECT_TIMEOUT: Duration = Duration::from_millis(750);
+const DB_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct Database {


### PR DESCRIPTION
This helps when starting the containerized node in `podman-compose` afresh (because the postgres startup takes some time when the DB schema is being created the first time).