### PR TITLE
Add git metadata into gevulot node build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,6 +3,9 @@ FROM rust:1-bookworm
 COPY ./Cargo.* ./
 COPY ./crates ./crates
 
+# Add .git to crates/node in order to build version metadata into binary.
+COPY ./.git ./crates/node/.git
+
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   libssl-dev \
   protobuf-compiler


### PR DESCRIPTION
Build git metadata into gevulot node binary for better diagnostics support.