### PR TITLE
Rename node binary's key generation command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -193,7 +193,7 @@ This guide uses `/var/lib/gevulot`, which is also the default, but it is configu
 
 Each Gevulot node requires a keypair for operation. It can be generated with Gevulot node container:
 ```
-podman run -it -v /var/lib/gevulot:/var/lib/gevulot:z quay.io/gevulot/node:latest generate node-key 
+podman run -it -v /var/lib/gevulot:/var/lib/gevulot:z quay.io/gevulot/node:latest generate key
 ```
 
 ## Gevulot node systemd unit

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -115,13 +115,13 @@ pub struct Config {
 }
 
 #[derive(Debug, Args)]
-pub struct NodeKeyOptions {
+pub struct KeyOptions {
     #[arg(
         long,
-        long_help = "Node key filename",
+        long_help = "Key filename",
         default_value_os_t = PathBuf::from("/var/lib/gevulot/node.key"),
     )]
-    pub node_key_file: PathBuf,
+    pub key_file: PathBuf,
 }
 
 #[derive(Debug, Subcommand)]
@@ -174,9 +174,14 @@ pub struct P2PBeaconConfig {
 
 #[derive(Debug, Subcommand)]
 pub enum GenerateCommand {
+    Key {
+        #[command(flatten)]
+        options: KeyOptions,
+    },
+    // NOTE: Depracated. Will be eventually removed. Use `Key` instead.
     NodeKey {
         #[command(flatten)]
-        options: NodeKeyOptions,
+        options: KeyOptions,
     },
 }
 


### PR DESCRIPTION
`gevulot generate node-key` -> `gevulot generate key`

The `node-key` command still exists, but will be phased out. The new command name allows for more ubiquitous use of gevulot container e.g. in prover/verifier development purposes.

**NOTE:** I added bunch of you as reviewers just to make you aware of this change :slightly_smiling_face: 