### PR TITLE
Make centrally managed whitelist optional

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -7,10 +7,9 @@ pub struct Config {
     #[arg(
         long,
         long_help = "Peer whitelist URL",
-        env = "GEVULOT_ACL_WHITELIST_URL",
-        default_value = "https://gevulot.com/acl/devnet.gz"
+        env = "GEVULOT_ACL_WHITELIST_URL"
     )]
-    pub acl_whitelist_url: String,
+    pub acl_whitelist_url: Option<String>,
 
     #[arg(
         long,

--- a/crates/node/src/rpc_server/mod.rs
+++ b/crates/node/src/rpc_server/mod.rs
@@ -450,7 +450,7 @@ mod tests {
 
     async fn new_rpc_server() -> RpcServer {
         let cfg = Arc::new(Config {
-            acl_whitelist_url: "http://127.0.0.1:0/does.not.exist".to_string(),
+            acl_whitelist_url: None,
             data_directory: temp_dir(),
             db_url: "postgres://gevulot:gevulot@localhost/gevulot".to_string(),
             json_rpc_listen_addr: "127.0.0.1:0".parse().unwrap(),


### PR DESCRIPTION
There are use cases (such as local dev node) where import of centrally managed whitelist doesn't make sense so make it optional.