### PR TITLE
Restructure `Cargo.toml` for the node crate

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -4,52 +4,81 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[[bin]]
-name = "gevulot"
-path = "src/main.rs"
-
 [dependencies]
-async-trait = "0.1.74"
 bincode = "1.3"
 blake3 = "1.5"
-bytes = "1.5"
-clap = { version = "4", features = ["derive", "env", "string"] }
-console-subscriber = "0.2"
-ecies = {version = "0.2", default-features = false, features = ["pure"]}
+ecies = { version = "0.2", default-features = false, features = ["pure"] }
 eyre = "0.6.8"
-futures = "0.3.30"
-futures-util = { version = "0.3", features = [ "io" ] }
 hex = "0.4"
-home = "0.5"
-http-body-util = "0.1"
-hyper = { version = "1", features = ["full"] }
-hyper-util = { version = "0.1", features = ["full"] }
 jsonrpsee = { version = "0.20", features = [ "client", "server" ] }
 libsecp256k1 = "0.7"
 num-bigint = { version = "0.4", features = [ "serde" ] }
-num-traits = "0.2"
-parking_lot = "0.12"
-pea2pea = "0.48"
-prost = "0.11"
-qapi = { version = "0.14", features = [ "qmp", "async-tokio-net" ]}
 rand = { version = "0.8", features = [ "std_rng" ] }
 reqwest = { version = "0.11", features = [ "gzip", "stream" ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "^1.0.9"
 sha3 = "0.10"
-snow = "0.9"
 sqlx = { version = "0.7", features = ["postgres", "migrate", "runtime-tokio", "rust_decimal", "time", "tls-rustls", "uuid"] }
 thiserror = "1"
 tokio = { version = "1", features = ["full", "io-util", "tracing"] }
-tokio-stream = "0.1"
-tokio-util = "0.7"
-tokio-vsock = { version = "0.4.0", features = ["tonic-conn"] }
-tonic = "0.8.3"
-tower = "0.4.0"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-vsock = "0.3.0"
 uuid = { version = "1", features = [ "v4", "fast-rng", "macro-diagnostics", "serde" ] }
+
+async-trait = { version = "0.1.74", optional = true }
+bytes = { version = "1.5", optional = true }
+clap = { version = "4", features = ["derive", "env", "string"], optional = true }
+console-subscriber = { version = "0.2", optional = true }
+futures = { version = "0.3.30", optional = true }
+futures-util = { version = "0.3", features = [ "io" ], optional = true }
+home = { version = "0.5", optional = true}
+http-body-util = { version = "0.1", optional = true }
+hyper = { version = "1", features = ["full"], optional = true }
+hyper-util = { version = "0.1", features = ["full"], optional = true }
+num-traits = { version = "0.2", optional = true }
+parking_lot = { version = "0.12", optional = true }
+pea2pea = { version = "0.48", optional = true }
+prost = { version = "0.11", optional = true }
+qapi = { version = "0.14", features = [ "qmp", "async-tokio-net" ], optional = true }
+snow = { version = "0.9", optional = true }
+tokio-stream = { version = "0.1", optional = true }
+tokio-util = { version = "0.7", optional = true }
+tokio-vsock = { version = "0.4.0", features = ["tonic-conn"], optional = true }
+tonic = { version = "0.8.3", optional = true }
+tower = { version = "0.4.0", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+vsock = { version = "0.3.0", optional = true }
+
+[features]
+build-binary = [
+  "async-trait",
+  "bytes",
+  "clap",
+  "console-subscriber",
+  "futures",
+  "futures-util",
+  "home",
+  "http-body-util",
+  "hyper",
+  "hyper-util",
+  "num-traits",
+  "parking_lot",
+  "pea2pea",
+  "prost",
+  "qapi",
+  "snow",
+  "tokio-stream",
+  "tokio-util",
+  "tokio-vsock",
+  "tonic",
+  "tower",
+  "tracing-subscriber",
+  "vsock",
+]
+
+[[bin]]
+name = "gevulot"
+path = "src/main.rs"
+required-features = [ "build-binary" ]
 
 [build-dependencies]
 tonic-build = "0.8"


### PR DESCRIPTION
Node crate contains both, the node binary, but also the library for writing e.g. JSON-RPC clients or building transactions out of the node.

In order to avoid certain dependencies in the library (most notably the vsock related ones), those problematic dependencies are marked as optional and moved behind a feature flag that the binary build depends on.