### PR TITLE
Only allocate GPU if requirements need it

### DIFF
--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -244,7 +244,7 @@ impl Provider for Qemu {
             .args(["-qmp", &format!("tcp:localhost:{qmp_port},server")]);
 
         // TODO: When GPU argument handling is refactored, this should be fixed as well.
-        if self.config.gpu_devices.is_some() {
+        if self.config.gpu_devices.is_some() && req.gpus > 0 {
             cmd.args(parse_gpu_devices_into_qemu_params(
                 self.config.gpu_devices.as_ref().unwrap(),
             ));


### PR DESCRIPTION
Now that it's possible to provide program specific resource requirements, the GPU should be only allocated when it's requested.

There's still plenty of room for improvement here (mainly allocating the right amount and fee GPUs), but this quick fix should help for the most immediate issues.