### PR TITLE
Fix container build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   libssl-dev \
   protobuf-compiler
 
-RUN cargo build --release
+RUN cargo build --features="node-binary" --release
 
 FROM debian:bookworm
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -49,7 +49,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 vsock = { version = "0.3.0", optional = true }
 
 [features]
-build-binary = [
+node-binary = [
   "async-trait",
   "bytes",
   "clap",
@@ -78,7 +78,7 @@ build-binary = [
 [[bin]]
 name = "gevulot"
 path = "src/main.rs"
-required-features = [ "build-binary" ]
+required-features = [ "node-binary" ]
 
 [build-dependencies]
 tonic-build = "0.8"


### PR DESCRIPTION
Due to separation of dependencies between Gevulot node binary and library, now the required feature flag (`node-binary`) must be specified in order to yield the node binary from the build.