### PR TITLE
Simplify build: Invert the node-binary feature flag

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0.71"
 blake3 = { version = "1.5", features = [ "mmap" ] }
 clap = { version = "4.0.29", features = ["derive"] }
 futures-util = { version = "0.3", default-features = false }
-gevulot-node = { path = "../node" }
+gevulot-node = { path = "../node", default-features = false }
 hex = "0.4"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 vsock = { version = "0.3.0", optional = true }
 
 [features]
+default = ["node-binary"]
 node-binary = [
   "async-trait",
   "bytes",


### PR DESCRIPTION
This change allows building everything from the workspace by-default, but allows reduced dependencies when only building `gevulot-cli`.