### PR TITLE
Improve txfile URL handling

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -258,7 +258,7 @@ async fn run(config: Arc<Config>) -> Result<()> {
         "http://{}:{}",
         config
             .p2p_advertised_listen_addr
-            .unwrap_or_else(|| p2p_listen_addr)
+            .unwrap_or(p2p_listen_addr)
             .ip(),
         config.http_download_port
     );


### PR DESCRIPTION
The address generated for txfile URL originates from the P2P bind address. In case the node is behind NAT, the address should take this into account.