### PR TITLE
Add program resource requirement support to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e063d263364859dc54fb064cedb7c122740cd4733644b14b176c097f51e8ab7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1127,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "clap",
+ "clap-num",
  "futures-util",
  "gevulot-node",
  "hex",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 anyhow = "1.0.71"
 blake3 = { version = "1.5", features = [ "mmap" ] }
 clap = { version = "4.0.29", features = ["derive"] }
+clap-num = "1"
 futures-util = { version = "0.3", default-features = false }
 gevulot-node = { path = "../node", default-features = false }
 hex = "0.4"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,5 @@
 use crate::file::FileData;
+use gevulot_node::types::program::ResourceRequest;
 use gevulot_node::types::transaction::{Created, ProgramMetadata};
 use gevulot_node::types::Hash;
 use gevulot_node::{
@@ -164,6 +165,8 @@ pub async fn run_deploy_command(
     verifier: String,
     prover_img_url: Option<String>,
     verifier_img_url: Option<String>,
+    prover_reqs: Option<ResourceRequest>,
+    verifier_reqs: Option<ResourceRequest>,
     listen_addr: SocketAddr,
 ) -> BoxResult<(String, String, String)> {
     let key = keyfile::read_key_file(&keyfile).map_err(|err| {
@@ -182,9 +185,13 @@ pub async fn run_deploy_command(
     let prover_data: FileData = file_data.swap_remove(0);
     let verifier_data: FileData = file_data.swap_remove(0);
 
-    let prover_prg_data: ProgramMetadata = prover_data.into();
+    let mut prover_prg_data: ProgramMetadata = prover_data.into();
+    prover_prg_data.resource_requirements = prover_reqs;
+    prover_prg_data.update_hash();
     let prover_prg_hash = prover_prg_data.hash;
-    let verifier_prg_data: ProgramMetadata = verifier_data.into();
+    let mut verifier_prg_data: ProgramMetadata = verifier_data.into();
+    verifier_prg_data.resource_requirements = verifier_reqs;
+    verifier_prg_data.update_hash();
     let verifier_prg_hash = verifier_prg_data.hash;
 
     let tx = Transaction::new(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -137,27 +137,24 @@ fn resource_requirements(
     mem: Option<u64>,
     gpus: Option<u64>,
 ) -> Option<ResourceRequest> {
-    let mut req = None;
+    if cpus.is_none() && mem.is_none() && gpus.is_none() {
+        return None;
+    }
+
+    let mut req = ResourceRequest::default();
     if cpus.is_some() {
-        req = Some(ResourceRequest::default());
-        req.map(|ref mut r| r.cpus = cpus.unwrap());
+        req.cpus = cpus.unwrap();
     }
 
     if mem.is_some() {
-        if req.is_none() {
-            req = Some(ResourceRequest::default());
-        }
-        req.map(|ref mut r| r.mem = mem.unwrap());
+        req.mem = mem.unwrap();
     }
 
     if gpus.is_some() {
-        if req.is_none() {
-            req = Some(ResourceRequest::default());
-        }
-        req.map(|ref mut r| r.gpus = gpus.unwrap());
+        req.gpus = gpus.unwrap();
     }
 
-    req
+    Some(req)
 }
 
 #[tokio::main]
@@ -265,10 +262,12 @@ fn print_tx_tree(tree: &TransactionTree, indentation: u16) {
 mod tests {
     use crate::*;
 
+    #[test]
     fn test_default_resource_requirements() {
         assert_eq!(resource_requirements(None, None, None), None);
     }
 
+    #[test]
     fn test_cpus_resource_requirements() {
         assert_eq!(
             resource_requirements(Some(16), None, None),
@@ -279,6 +278,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_mem_resource_requirements() {
         assert_eq!(
             resource_requirements(None, Some(24576), None),
@@ -289,6 +289,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_gpus_resource_requirements() {
         assert_eq!(
             resource_requirements(None, None, Some(1)),
@@ -299,6 +300,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_cpu_mem_requirements() {
         assert_eq!(
             resource_requirements(Some(4), Some(4096), None),


### PR DESCRIPTION
Add support to specify program resource requirements into `gevulot-cli` tool. This is needed so that different provers & verifiers can run with reasonable resource requirements and therefore allow for concurrency, but also for exclusive rights to HW when needed.