### PR TITLE
Add flag for --no-execution to disable tx exec v2

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 vsock = { version = "0.3.0", optional = true }
 
 [features]
+default = ["node-binary"]
 node-binary = [
   "async-trait",
   "bytes",

--- a/crates/node/src/mempool/mod.rs
+++ b/crates/node/src/mempool/mod.rs
@@ -1,3 +1,4 @@
+use crate::txvalidation::ValidatedTxreceiver;
 use crate::types::{transaction::Validated, Hash, Transaction};
 use async_trait::async_trait;
 use eyre::Result;
@@ -50,5 +51,12 @@ impl Mempool {
 
     pub fn size(&self) -> usize {
         self.deque.len()
+    }
+}
+
+#[async_trait]
+impl ValidatedTxreceiver for Mempool {
+    async fn send_new_tx(&mut self, tx: Transaction<Validated>) -> eyre::Result<()> {
+        self.add(tx).await
     }
 }


### PR DESCRIPTION
About the #111 PR discussion, I try to separate each domain, so that when you don't need all domain to start, you can avoid it.
This is the easiest implementation I see to keep the domain separated without changing many things.
So for archive mode, the scheduler is not started.

The main diff with other PR is that we don't change the sheduler code because we add a new mode that don't need it.

I think the natural evolution is to define a mempool domain that validate Tx. The tx_validate mod is under mempool.
Mempool propagate tx then send the tx to other domains: Execution (scheduler) and storage.

Not sure the mempool can store the Tx too when it's validated.
Often, Storage is a horizontal domain. That why the storage can be split among domain. Here, for example, the save Tx is implemented only inside mempool. This way we are sure that Tx are saved only by the mempool when it should be. 
