### PR TITLE
Fetch program with resource requests if exists

### DIFF
--- a/crates/node/src/storage/database/postgres.rs
+++ b/crates/node/src/storage/database/postgres.rs
@@ -10,7 +10,6 @@ use crate::types::{
 use eyre::Result;
 use gevulot_node::types::program::ResourceRequest;
 use libsecp256k1::PublicKey;
-use sqlx::Acquire;
 use sqlx::{postgres::PgPoolOptions, FromRow, Row};
 use std::time::Duration;
 


### PR DESCRIPTION
`Database.find_program(..)` is used e.g. in program manager, which depends on embedded program resource requests, if such are configured.

Old version of this method didn't fetch them along the program data, so the method is now a wrapper for `get_program(..)` but handles error as non-existing program.