### PR TITLE
Set vmid txhash link

### DIFF
--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -325,7 +325,7 @@ impl Scheduler {
                         vm_handle.vm_id(),
                         vm_handle.run_time()
                     );
-                    zombies.push(tx_hash.clone());
+                    zombies.push(*tx_hash);
                 }
             }
         }
@@ -445,8 +445,7 @@ impl TaskManager for Scheduler {
                 .files
                 .into_iter()
                 .map(|file| {
-                    let vm_file =
-                        TaskVmFile::<VmOutput>::new(file.path.to_string(), tx_hash.clone().into());
+                    let vm_file = TaskVmFile::<VmOutput>::new(file.path.to_string(), tx_hash);
                     let dest = TxFile::<Output>::new(
                         file.path,
                         self.http_download_host.clone(),

--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -7,7 +7,7 @@ use crate::txvalidation::TxResultSender;
 use crate::types::file::{move_vmfile, Output, TaskVmFile, TxFile, VmOutput};
 use crate::types::TaskState;
 use crate::vmm::vm_server::grpc;
-use crate::vmm::{vm_server::TaskManager, VMId};
+use crate::vmm::vm_server::TaskManager;
 use crate::workflow::{WorkflowEngine, WorkflowError};
 use crate::{
     mempool::Mempool,
@@ -41,15 +41,14 @@ const MAX_VM_IDLE_RUN_TIME: Duration = Duration::from_secs(10);
 
 struct RunningTask {
     task: Task,
-    vm_id: Arc<dyn VMId>,
     task_scheduled: Instant,
     task_started: Instant,
 }
 
 struct SchedulerState {
     pending_programs: VecDeque<(Hash, Hash)>,
-    running_tasks: Vec<RunningTask>,
-    running_vms: Vec<ProgramHandle>,
+    running_tasks: HashMap<Hash, RunningTask>,
+    running_vms: HashMap<Hash, ProgramHandle>,
     task_queue: HashMap<Hash, VecDeque<(Task, Instant)>>,
 }
 
@@ -57,8 +56,8 @@ impl SchedulerState {
     fn new() -> Self {
         Self {
             pending_programs: VecDeque::new(),
-            running_tasks: vec![],
-            running_vms: vec![],
+            running_tasks: HashMap::new(),
+            running_vms: HashMap::new(),
             task_queue: HashMap::new(),
         }
     }
@@ -125,7 +124,9 @@ impl Scheduler {
                         .start_program(tx_hash, program_id, None)
                         .await
                     {
-                        Ok(p) => state.running_vms.push(p),
+                        Ok(p) => {
+                            state.running_vms.insert(tx_hash, p);
+                        }
                         Err(e) if e.is::<ResourceError>() => {
                             let err = e.downcast_ref::<ResourceError>().unwrap();
                             tracing::info!("resources unavailable: {}", err);
@@ -171,7 +172,9 @@ impl Scheduler {
                 .start_program(task.tx, task.program_id, None)
                 .await
             {
-                Ok(p) => self.state.lock().await.running_vms.push(p),
+                Ok(p) => {
+                    self.state.lock().await.running_vms.insert(task.tx, p);
+                }
                 Err(ref err) => {
                     if let Some(err) = err.downcast_ref::<ResourceError>() {
                         let ResourceError::NotEnoughResources(msg) = err;
@@ -247,14 +250,10 @@ impl Scheduler {
         let mut state = self.state.lock().await;
 
         let mut zombies = vec![];
-        for task in state.running_tasks.iter() {
+        for task in state.running_tasks.values() {
             // TODO: Add maximum running time limit for a task here.
 
-            if let Some(vm_handle) = state
-                .running_vms
-                .iter()
-                .find(|x| x.vm_id().eq(task.vm_id.clone()))
-            {
+            if let Some(vm_handle) = state.running_vms.get(&task.task.tx) {
                 tracing::trace!(
                     "inspecting if VM for task id {} is still alive",
                     task.task.id
@@ -268,42 +267,33 @@ impl Scheduler {
                         // VM is not running anymore.
                         tracing::warn!(
                             "VM {} running for task (id: {}, tx hash: {}) has stopped",
-                            task.vm_id,
+                            vm_handle.vm_id(),
                             task.task.id,
                             task.task.tx
                         );
-                        zombies.push((task.task.id, task.vm_id.clone()));
+                        zombies.push(task.task.tx);
                     }
                     Err(err) => {
-                        tracing::error!("failed to query VM state for {} running task (id: {}, tx hash: {}): {}", task.vm_id, task.task.id, task.task.tx, err);
-                        zombies.push((task.task.id, task.vm_id.clone()));
+                        tracing::error!("failed to query VM state for {} running task (id: {}, tx hash: {}): {}", vm_handle.vm_id(), task.task.id, task.task.tx, err);
+                        zombies.push(task.task.tx);
                     }
                 }
             } else {
                 // VM doesn't exist. Shouldn't happen...
-                tracing::error!("found task (id: {}, tx hash: {}) running on VM {} but not the corresponding running VM", task.task.id, task.task.tx, task.vm_id);
-                zombies.push((task.task.id, task.vm_id.clone()));
+                tracing::error!("found task (id: {}, tx hash: {}) running on VM but not the corresponding running VM", task.task.id, task.task.tx);
+                zombies.push(task.task.tx);
             }
         }
 
-        while let Some((task_id, vm_id)) = zombies.pop() {
-            tracing::debug!(
-                "reaping stopped task (id: {}) running on VM {}",
-                task_id,
-                vm_id
-            );
+        while let Some(task_tx) = zombies.pop() {
+            tracing::debug!("reaping stopped task (tx: {}) running on VM", task_tx,);
 
             // For each zombie task:
             // - Stop the VM.
             // - Remove the VM from the `running_vms`.
             // - Remove the task from the `running_tasks`.
             //
-            if let Some(idx) = state
-                .running_vms
-                .iter()
-                .position(|x| x.vm_id().eq(vm_id.clone()))
-            {
-                let vm_handle = state.running_vms.swap_remove(idx);
+            if let Some(vm_handle) = state.running_vms.remove(&task_tx) {
                 if let Err(err) = self
                     .program_manager
                     .lock()
@@ -311,27 +301,18 @@ impl Scheduler {
                     .stop_program(vm_handle)
                     .await
                 {
-                    tracing::error!("failed to stop VM {}: {}", vm_id, err);
+                    tracing::error!("failed to stop VMvm_handle {}", err);
                 }
             }
 
-            if let Some(idx) = state
-                .running_tasks
-                .iter()
-                .position(|x| x.task.id == task_id)
-            {
-                let _ = state.running_tasks.swap_remove(idx);
-            }
+            //TODO cancel associated Tx
+            state.running_tasks.remove(&task_tx);
         }
 
         // Now, reap VMs that don't have running task.
         let mut zombies = vec![];
-        for vm_handle in state.running_vms.iter() {
-            if !state
-                .running_tasks
-                .iter()
-                .any(|x| x.vm_id.eq(vm_handle.vm_id()))
-            {
+        for (tx_hash, vm_handle) in state.running_vms.iter() {
+            if !state.running_tasks.contains_key(tx_hash) {
                 // XXX: Following is not 100% correct. It checks the runtime
                 // from the very beginning of the whole VM's start-up, which
                 // is not the same as idle runtime. However, right now each VM
@@ -344,28 +325,25 @@ impl Scheduler {
                         vm_handle.vm_id(),
                         vm_handle.run_time()
                     );
-                    zombies.push(vm_handle.vm_id());
+                    zombies.push(tx_hash.clone());
                 }
             }
         }
 
-        while let Some(vm_id) = zombies.pop() {
-            tracing::debug!("reaping idle VM {}", vm_id);
+        while let Some(tx_hash) = zombies.pop() {
+            tracing::debug!("reaping idle VM for tx {}", tx_hash);
 
-            if let Some(idx) = state
-                .running_vms
-                .iter()
-                .position(|x| x.vm_id().eq(vm_id.clone()))
-            {
-                let vm_handle = state.running_vms.swap_remove(idx);
-                if let Err(err) = self
-                    .program_manager
-                    .lock()
-                    .await
-                    .stop_program(vm_handle)
-                    .await
-                {
-                    tracing::error!("failed to stop VM {}: {}", vm_id, err);
+            if let Some(idx) = state.running_vms.get(&tx_hash) {
+                if let Some(vm_handle) = state.running_vms.remove(&tx_hash) {
+                    if let Err(err) = self
+                        .program_manager
+                        .lock()
+                        .await
+                        .stop_program(vm_handle)
+                        .await
+                    {
+                        tracing::error!("failed to stop VM  for Tx {}: {}", tx_hash, err);
+                    }
                 }
             }
         }
@@ -374,46 +352,28 @@ impl Scheduler {
 
 #[async_trait]
 impl TaskManager for Scheduler {
-    async fn get_running_task(&self, vm_id: Arc<dyn VMId>) -> Option<Task> {
+    async fn get_running_task(&self, tx_hash: Hash) -> Option<Task> {
         let state = self.state.lock().await;
-        state
-            .running_tasks
-            .iter()
-            .find(|rt| rt.vm_id.eq(vm_id.clone()))
-            .map(|rt| rt.task.clone())
+        state.running_tasks.get(&tx_hash).map(|t| t.task.clone())
     }
 
-    async fn get_pending_task(&self, tx_hash: Hash, vm_id: Arc<dyn VMId>) -> Option<Task> {
-        tracing::debug!(
-            "tx {} running in vm_id {} requests for new task",
-            tx_hash,
-            vm_id
-        );
+    async fn get_pending_task(&self, tx_hash: Hash) -> Option<Task> {
+        tracing::debug!("tx {} running requests for new task", tx_hash,);
 
         // Ensure that the VM requesting for a task is not already executing one!
         let mut state = self.state.lock().await;
-        if let Some(idx) = state
-            .running_tasks
-            .iter()
-            .position(|e| e.vm_id.eq(vm_id.clone()))
-        {
+        if let Some(running_task) = state.running_tasks.get(&tx_hash) {
             // A VM that is already running a task, requests for a new one.
             // Mark the existing task as executed and stop the VM.
-            let running_task = state.running_tasks.swap_remove(idx);
             tracing::info!(
                 "task {} has been running {}sec but found to be orphaned. marking it as executed.",
                 running_task.task.id,
                 running_task.task_started.elapsed().as_secs()
             );
 
-            tracing::debug!("terminating VM {} running tx {}", vm_id, tx_hash);
+            tracing::debug!("terminating VM running tx {}", tx_hash);
 
-            let idx = state
-                .running_vms
-                .iter()
-                .position(|e| e.vm_id().eq(vm_id.clone()));
-            if idx.is_some() {
-                let program_handle = state.running_vms.remove(idx.unwrap());
+            if let Some(program_handle) = state.running_vms.remove(&tx_hash) {
                 if let Err(err) = self
                     .program_manager
                     .lock()
@@ -430,24 +390,21 @@ impl TaskManager for Scheduler {
 
         if let Some(task_queue) = state.task_queue.get_mut(&tx_hash) {
             if let Some((task, scheduled)) = task_queue.pop_front() {
-                tracing::debug!(
-                    "task {} found for tx {} running in vm_id {}",
-                    task.id,
-                    tx_hash,
-                    vm_id
-                );
+                tracing::debug!("task {} found for tx {} running", task.id, tx_hash,);
                 tracing::info!(
                     "task {} started in {}ms",
                     task.id,
                     scheduled.elapsed().as_millis()
                 );
 
-                state.running_tasks.push(RunningTask {
-                    task: task.clone(),
-                    vm_id: vm_id.clone(),
-                    task_scheduled: scheduled,
-                    task_started: Instant::now(),
-                });
+                state.running_tasks.insert(
+                    task.tx,
+                    RunningTask {
+                        task: task.clone(),
+                        task_scheduled: scheduled,
+                        task_started: Instant::now(),
+                    },
+                );
 
                 return Some(task.clone());
             }
@@ -459,7 +416,6 @@ impl TaskManager for Scheduler {
     async fn submit_result(
         &self,
         program: Hash,
-        vm_id: Arc<dyn VMId>,
         result: grpc::task_result_request::Result,
     ) -> Result<(), String> {
         tracing::debug!("submit_result  result:{result:#?} ");
@@ -468,14 +424,9 @@ impl TaskManager for Scheduler {
             todo!("task failed; handle it correctly")
         };
 
-        let task_id = &result.id;
+        let tx_hash: Hash = (&*result.id).into();
         let mut state = self.state.lock().await;
-        if let Some(idx) = state
-            .running_tasks
-            .iter()
-            .position(|e| &e.task.tx.to_string() == task_id)
-        {
-            let running_task = state.running_tasks.swap_remove(idx);
+        if let Some(running_task) = state.running_tasks.remove(&tx_hash) {
             tracing::info!(
                 "task of Tx {} finished in {}sec",
                 running_task.task.tx,
@@ -495,7 +446,7 @@ impl TaskManager for Scheduler {
                 .into_iter()
                 .map(|file| {
                     let vm_file =
-                        TaskVmFile::<VmOutput>::new(file.path.to_string(), task_id.clone().into());
+                        TaskVmFile::<VmOutput>::new(file.path.to_string(), tx_hash.clone().into());
                     let dest = TxFile::<Output>::new(
                         file.path,
                         self.http_download_host.clone(),
@@ -554,24 +505,22 @@ impl TaskManager for Scheduler {
                 format!("failed to send Tx result to validation process: {}", err)
             })?;
 
-            tracing::debug!("terminating VM {} running program {}", vm_id, program);
+            tracing::debug!("terminating VM running program {}", program);
 
-            let idx = state
-                .running_vms
-                .iter()
-                .position(|e| e.vm_id().eq(vm_id.clone()));
-            if idx.is_some() {
-                let program_handle = state.running_vms.remove(idx.unwrap());
-                self.program_manager
-                    .lock()
-                    .await
-                    .stop_program(program_handle)
-                    .await
-                    .map_err(|err| format!("failed to stop program {}: {}", program, err))?;
+            match state.running_vms.remove(&tx_hash) {
+                Some(program_handle) => {
+                    self.program_manager
+                        .lock()
+                        .await
+                        .stop_program(program_handle)
+                        .await
+                        .map_err(|err| format!("failed to stop program {}: {}", program, err))?;
+                }
+                None => tracing::warn!("Running VM not found for a Tx result: {tx_hash}"),
             }
             Ok(())
         } else {
-            Err(format!("submit_result task:{task_id} not found."))
+            Err(format!("submit_result task:{tx_hash} not found."))
         }
     }
 }

--- a/crates/node/src/vmm/mod.rs
+++ b/crates/node/src/vmm/mod.rs
@@ -1,3 +1,4 @@
+use gevulot_node::types::Hash;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -42,7 +43,12 @@ impl VMHandle {
 
 #[async_trait]
 pub trait Provider: Send + Sync {
-    async fn start_vm(&mut self, program: Program, req: ResourceRequest) -> Result<VMHandle>;
+    async fn start_vm(
+        &mut self,
+        tx_hash: Hash,
+        program: Program,
+        req: ResourceRequest,
+    ) -> Result<VMHandle>;
     fn stop_vm(&mut self, vm: VMHandle) -> Result<()>;
 
     fn prepare_image(&mut self, program: Program, image: &Path) -> Result<()>;

--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -127,7 +127,6 @@ impl ProgramRegistry for Qemu {
             Some(addr) => {
                 self.vm_registry
                     .get(&addr.cid())
-                    //                    .map(|handle| -> (Hash, Arc<dyn VMId>) {
                     .map(|handle| -> (Hash, Hash, Arc<dyn VMId>) {
                         (handle.tx_hash, handle.program_id, Arc::new(addr.cid()))
                     })

--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -57,7 +57,8 @@ fn u32_from_any(x: &dyn Any) -> u32 {
 pub struct QEMUVMHandle {
     child: Option<Child>,
     cid: u32,
-    program_id: Hash,
+    tx_hash: Hash,
+    program_idd: Hash,
     workspace_volume_label: String,
     //qmp: Arc<Mutex<Qmp>>,
 }
@@ -120,14 +121,15 @@ impl Qemu {
 }
 
 impl ProgramRegistry for Qemu {
-    fn find_by_req(&mut self, extensions: &Extensions) -> Option<(Hash, Arc<dyn VMId>)> {
+    fn find_by_req(&mut self, extensions: &Extensions) -> Option<(Hash, Hash, Arc<dyn VMId>)> {
         let conn_info = extensions.get::<VsockConnectInfo>().unwrap();
         match conn_info.peer_addr() {
             Some(addr) => {
                 self.vm_registry
                     .get(&addr.cid())
-                    .map(|handle| -> (Hash, Arc<dyn VMId>) {
-                        (handle.program_id, Arc::new(addr.cid()))
+                    //                    .map(|handle| -> (Hash, Arc<dyn VMId>) {
+                    .map(|handle| -> (Hash, Hash, Arc<dyn VMId>) {
+                        (handle.tx_hash, handle.program_idd, Arc::new(addr.cid()))
                     })
             }
             None => None,
@@ -137,7 +139,12 @@ impl ProgramRegistry for Qemu {
 
 #[async_trait]
 impl Provider for Qemu {
-    async fn start_vm(&mut self, program: Program, req: ResourceRequest) -> Result<VMHandle> {
+    async fn start_vm(
+        &mut self,
+        tx_hash: Hash,
+        program: Program,
+        req: ResourceRequest,
+    ) -> Result<VMHandle> {
         // TODO:
         //  - Builder to construct QEMU flags
         //  - Handle GPUs
@@ -172,11 +179,12 @@ impl Provider for Qemu {
         // watchdog will reap it.
         let qmp_port = (cid % 64512) + 1024;
 
-        let program_id = program.hash;
+        let program_idd = program.hash;
         let qemu_vm_handle = QEMUVMHandle {
             child: None,
             cid,
-            program_id,
+            tx_hash,
+            program_idd,
             workspace_volume_label,
             //qmp: Arc::new(Mutex::new(qmp)),
         };
@@ -252,7 +260,8 @@ impl Provider for Qemu {
 
         // Setup stdout & stderr log to VM execution.
         {
-            let log_dir_path = Path::new(&self.config.log_directory).join(program.hash.to_string());
+            // Change to have an unique log per Tx so that log are not mix between program execution.
+            let log_dir_path = Path::new(&self.config.log_directory).join(tx_hash.to_string());
             std::fs::create_dir_all(&log_dir_path)?;
             let stdout = File::options()
                 .create(true)
@@ -267,7 +276,7 @@ impl Provider for Qemu {
         }
 
         tracing::info!(
-            "Program:{} starting QEMU. args:\n{:#?}\n",
+            "Tx:{tx_hash} Program:{} starting QEMU. args:\n{:#?}\n",
             program.hash.to_string(),
             cmd.get_args(),
         );

--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -58,7 +58,7 @@ pub struct QEMUVMHandle {
     child: Option<Child>,
     cid: u32,
     tx_hash: Hash,
-    program_idd: Hash,
+    program_id: Hash,
     workspace_volume_label: String,
     //qmp: Arc<Mutex<Qmp>>,
 }
@@ -129,7 +129,7 @@ impl ProgramRegistry for Qemu {
                     .get(&addr.cid())
                     //                    .map(|handle| -> (Hash, Arc<dyn VMId>) {
                     .map(|handle| -> (Hash, Hash, Arc<dyn VMId>) {
-                        (handle.tx_hash, handle.program_idd, Arc::new(addr.cid()))
+                        (handle.tx_hash, handle.program_id, Arc::new(addr.cid()))
                     })
             }
             None => None,
@@ -179,12 +179,12 @@ impl Provider for Qemu {
         // watchdog will reap it.
         let qmp_port = (cid % 64512) + 1024;
 
-        let program_idd = program.hash;
+        let program_id = program.hash;
         let qemu_vm_handle = QEMUVMHandle {
             child: None,
             cid,
             tx_hash,
-            program_idd,
+            program_id,
             workspace_volume_label,
             //qmp: Arc::new(Mutex::new(qmp)),
         };

--- a/crates/node/src/vmm/vm_server.rs
+++ b/crates/node/src/vmm/vm_server.rs
@@ -32,7 +32,7 @@ const DATA_STREAM_CHUNK_SIZE: usize = 4096;
 /// requesting for work and submitting results of tasks.
 #[async_trait]
 pub trait TaskManager: Send + Sync {
-    async fn get_pending_task(&self, program: Hash, vm_id: Arc<dyn VMId>) -> Option<Task>;
+    async fn get_pending_task(&self, tx_hash: Hash, vm_id: Arc<dyn VMId>) -> Option<Task>;
     async fn get_running_task(&self, vm_id: Arc<dyn VMId>) -> Option<Task>;
     async fn submit_result(
         &self,
@@ -45,7 +45,7 @@ pub trait TaskManager: Send + Sync {
 /// ProgramRegistry defines interface that `VMServer` uses to identify which
 /// `Program` sent corresponding request.
 pub trait ProgramRegistry: Send {
-    fn find_by_req(&mut self, extensions: &Extensions) -> Option<(Hash, Arc<dyn VMId>)>;
+    fn find_by_req(&mut self, extensions: &Extensions) -> Option<(Hash, Hash, Arc<dyn VMId>)>;
 }
 
 /// VMServer is the integration point between Gevulot node and individual
@@ -91,7 +91,7 @@ impl VmService for VMServer {
         request: Request<TaskRequest>,
     ) -> Result<Response<TaskResponse>, Status> {
         tracing::info!("request for task: {:?}", request);
-        let (program, vm_id) = self
+        let (tx_hash, program_id, vm_id) = self
             .program_registry
             .lock()
             .await
@@ -103,7 +103,7 @@ impl VmService for VMServer {
                 )
             })?;
 
-        let reply = match self.task_source.get_pending_task(program, vm_id).await {
+        let reply = match self.task_source.get_pending_task(tx_hash, vm_id).await {
             Some(task) => grpc::TaskResponse {
                 result: Some(grpc::task_response::Result::Task(grpc::Task {
                     id: task.tx.to_string(),
@@ -132,7 +132,7 @@ impl VmService for VMServer {
     ) -> Result<Response<Self::GetFileStream>, Status> {
         tracing::info!("request for file: {:?}", request);
 
-        let (program, vm_id) = self
+        let (tx_hash, program_id, vm_id) = self
             .program_registry
             .lock()
             .await
@@ -205,7 +205,7 @@ impl VmService for VMServer {
         &self,
         request: Request<Streaming<FileData>>,
     ) -> Result<Response<GenericResponse>, Status> {
-        let (program, vm_id) = match self
+        let (tx_hash, program_id, vm_id) = match self
             .program_registry
             .lock()
             .await
@@ -302,7 +302,7 @@ impl VmService for VMServer {
         &self,
         request: Request<TaskResultRequest>,
     ) -> Result<Response<TaskResultResponse>, Status> {
-        let (program, vm_id) = match self
+        let (tx_hash, program_id, vm_id) = match self
             .program_registry
             .lock()
             .await
@@ -319,13 +319,17 @@ impl VmService for VMServer {
 
         tracing::trace!(
             "VMServer submit_result program:{}, vm_id:{vm_id}",
-            program.to_string()
+            program_id.to_string()
         );
 
         let result = request.into_inner().result;
 
         if let Some(result) = result {
-            if let Err(err) = self.task_source.submit_result(program, vm_id, result).await {
+            if let Err(err) = self
+                .task_source
+                .submit_result(program_id, vm_id, result)
+                .await
+            {
                 tracing::error!("Error during submit VM execution result:{err}");
             }
         }


### PR DESCRIPTION
Most, I change to use Tx Hash to link task/Tx and Vm execution.
I remove VMId when it wasn't necessary for the logic.
I didn't touch the resource part.

I do a local test and the Txs execute correctly.

