### PR TITLE
Auto-detect available system resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+
+[[package]]
 name = "cc"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1204,7 @@ dependencies = [
  "libsecp256k1",
  "num-bigint",
  "num-traits",
+ "num_cpus",
  "parking_lot",
  "pea2pea",
  "prost 0.11.9",
@@ -1209,6 +1216,7 @@ dependencies = [
  "sha3",
  "snow",
  "sqlx",
+ "systemstat",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3660,6 +3668,20 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "systemstat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24aec24a9312c83999a28e3ef9db7e2afd5c64bf47725b758cdc1cafd5b0bd2"
+dependencies = [
+ "bytesize",
+ "lazy_static",
+ "libc",
+ "nom",
+ "time",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,12 +35,14 @@ home = { version = "0.5", optional = true}
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1", features = ["full"], optional = true }
 hyper-util = { version = "0.1", features = ["full"], optional = true }
+num_cpus = { version = "1.4.0", optional = true }
 num-traits = { version = "0.2", optional = true }
 parking_lot = { version = "0.12", optional = true }
 pea2pea = { version = "0.48", optional = true }
 prost = { version = "0.11", optional = true }
 qapi = { version = "0.14", features = [ "qmp", "async-tokio-net" ], optional = true }
 snow = { version = "0.9", optional = true }
+systemstat = { version = "0.2.3", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio-vsock = { version = "0.4.0", features = ["tonic-conn"], optional = true }
@@ -62,12 +64,14 @@ node-binary = [
   "http-body-util",
   "hyper",
   "hyper-util",
+  "num_cpus",
   "num-traits",
   "parking_lot",
   "pea2pea",
   "prost",
   "qapi",
   "snow",
+  "systemstat",
   "tokio-stream",
   "tokio-util",
   "tokio-vsock",

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -101,21 +101,15 @@ pub struct Config {
     )]
     pub vsock_listen_port: u32,
 
-    #[arg(
-        long,
-        long_help = "Number of CPUs available",
-        env = "GEVULOT_CPUS",
-        default_value_t = 8
-    )]
-    pub num_cpus: u64,
+    #[arg(long, long_help = "Number of CPUs available", env = "GEVULOT_CPUS")]
+    pub num_cpus: Option<u64>,
 
     #[arg(
         long,
         long_help = "Amount of memory available (in GBs)",
-        env = "GEVULOT_MEM_GB",
-        default_value_t = 8
+        env = "GEVULOT_MEM_GB"
     )]
-    pub mem_gb: u64,
+    pub mem_gb: Option<u64>,
 
     #[arg(long, long_help = "GPU PCI devices", env = "GEVULOT_GPU_DEVICES")]
     pub gpu_devices: Option<String>,

--- a/crates/node/src/rpc_server/mod.rs
+++ b/crates/node/src/rpc_server/mod.rs
@@ -442,8 +442,8 @@ mod tests {
             p2p_advertised_listen_addr: None,
             provider: "qemu".to_string(),
             vsock_listen_port: 8080,
-            num_cpus: 8,
-            mem_gb: 8,
+            num_cpus: None,
+            mem_gb: None,
             gpu_devices: None,
             http_download_port: 0,
         });


### PR DESCRIPTION
When number of CPUs or usable amount of RAM hasn't been specified by command line parameters (or env variables), auto-detect the system resources and use what the host has.