### PR TITLE
Add `created_at` timestamp to transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +529,21 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1189,6 +1219,7 @@ dependencies = [
  "bincode",
  "blake3",
  "bytes",
+ "chrono",
  "clap",
  "console-subscriber",
  "ecies",
@@ -1658,6 +1689,29 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3398,6 +3452,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "dotenvy",
@@ -3485,6 +3540,7 @@ dependencies = [
  "bitflags 2.4.2",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.10.7",
  "dotenvy",
@@ -3529,6 +3585,7 @@ dependencies = [
  "base64 0.21.7",
  "bitflags 2.4.2",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -3568,6 +3625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -4377,6 +4435,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 base64 = "0.21.7"
 bincode = "1.3"
 blake3 = "1.5"
+chrono = { version = "0.4", features = [ "serde" ] }
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 eyre = "0.6.8"
 hex = "0.4"
@@ -19,7 +20,7 @@ reqwest = { version = "0.11", features = [ "gzip", "stream" ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "^1.0.9"
 sha3 = "0.10"
-sqlx = { version = "0.7", features = ["postgres", "migrate", "runtime-tokio", "rust_decimal", "time", "tls-rustls", "uuid"] }
+sqlx = { version = "0.7", features = ["chrono", "postgres", "migrate", "runtime-tokio", "rust_decimal", "time", "tls-rustls", "uuid"] }
 thiserror = "1"
 tokio = { version = "1", features = ["full", "io-util", "tracing"] }
 tracing = "0.1"

--- a/crates/node/migrations/20240311123204_add-transaction-timestamp.sql
+++ b/crates/node/migrations/20240311123204_add-transaction-timestamp.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction ADD COLUMN created_at TIMESTAMPTZ DEFAULT NOW();

--- a/crates/node/src/storage/database/entity/transaction.rs
+++ b/crates/node/src/storage/database/entity/transaction.rs
@@ -27,6 +27,7 @@ pub struct Transaction {
     pub signature: Signature,
     pub propagated: bool,
     pub executed: bool,
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl From<&types::Transaction<transaction::Validated>> for Transaction {
@@ -52,6 +53,7 @@ impl From<&types::Transaction<transaction::Validated>> for Transaction {
             signature: value.signature,
             propagated: value.propagated,
             executed: value.executed,
+            created_at: None,
         }
     }
 }


### PR DESCRIPTION
Transaction creation timestamp can be used for categorizing historical transactions in to an immutable set that can be then used for syncing.

In Gevulot devnet, since there is no consensus, there is also no reliable way to order transactions correctly in a distributed system.

However, when each transaction still has a creation timestamp, that can be used as a snapshotting point where all historical transactions can be ordered by their hash and therefore grouped for quicker syncing.