### PR TITLE
Change Tx validation logic to add: Tx wait that its parent has been validated.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee",
  "libsecp256k1",
+ "lru",
  "num-bigint",
  "num-traits",
  "num_cpus",
@@ -2109,6 +2110,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "matchers"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -37,6 +37,7 @@ http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1", features = ["full"], optional = true }
 hyper-util = { version = "0.1", features = ["full"], optional = true }
 num_cpus = { version = "1.4.0", optional = true }
+lru = "0.12.3"
 num-traits = { version = "0.2", optional = true }
 parking_lot = { version = "0.12", optional = true }
 pea2pea = { version = "0.48", optional = true }

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -243,6 +243,7 @@ async fn run(config: Arc<Config>) -> Result<()> {
         database.clone(),
         rcv_tx_event_rx,
         new_validated_tx_receiver.clone(),
+        database.clone(),
     )
     .await?;
 

--- a/crates/node/src/txvalidation/download_manager.rs
+++ b/crates/node/src/txvalidation/download_manager.rs
@@ -52,7 +52,7 @@ pub async fn download_asset_file(
                     port.map(|port| {
                         //use parse to create an URL, no new method.
                         let mut url =
-                            reqwest::Url::parse(format!("{HTTP_SERVER_SCHEME}localhost")).unwrap(); //unwrap always succeed
+                            reqwest::Url::parse(&format!("{HTTP_SERVER_SCHEME}localhost")).unwrap(); //unwrap always succeed
                         url.set_ip_host(peer.ip()).unwrap(); //unwrap always succeed
                         url.set_port(Some(port)).unwrap(); //unwrap always succeed
                         url.set_path(&file_uri); //unwrap Path always ok

--- a/crates/node/src/txvalidation/download_manager.rs
+++ b/crates/node/src/txvalidation/download_manager.rs
@@ -51,7 +51,8 @@ pub async fn download_asset_file(
                 .filter_map(|(peer, port)| {
                     port.map(|port| {
                         //use parse to create an URL, no new method.
-                        let mut url = reqwest::Url::parse(HTTP_SERVER_SCHEME).unwrap(); //unwrap always succeed
+                        let mut url =
+                            reqwest::Url::parse(format!("{HTTP_SERVER_SCHEME}localhost")).unwrap(); //unwrap always succeed
                         url.set_ip_host(peer.ip()).unwrap(); //unwrap always succeed
                         url.set_port(Some(port)).unwrap(); //unwrap always succeed
                         url.set_path(&file_uri); //unwrap Path always ok

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -222,7 +222,8 @@ impl TxEvent<WaitTx> {
         let new_txs = new_tx
             .map(|tx| {
                 let mut ret = cache.remove_waiting_children_txs(&tx.tx.hash);
-                ret.push(tx);
+                // Add the parent Tx first to be processed the first.
+                ret.insert(0, tx);
                 ret
             })
             .unwrap_or(vec![]);

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -209,12 +209,12 @@ impl TxEvent<WaitTx> {
                 // Present return the Tx
                 Some(self)
             } else {
-                //parent is missing add to waiting list
+                // Parent is missing add to waiting list
                 cache.add_new_waiting_tx(*parent, self);
                 None
             }
         } else {
-            //no parent always new Tx.
+            // No parent always new Tx.
             Some(self)
         };
 

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -1,12 +1,17 @@
+use crate::mempool::Storage;
 use crate::txvalidation::acl::AclWhitelist;
 use crate::txvalidation::download_manager;
 use crate::txvalidation::EventProcessError;
+use crate::txvalidation::MAX_CACHED_TX_FOR_VERIFICATION;
+use crate::types::Hash;
 use crate::types::{
     transaction::{Received, Validated},
     Transaction,
 };
 use futures::future::join_all;
 use futures_util::TryFutureExt;
+use lru::LruCache;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -20,6 +25,9 @@ pub struct ReceivedTx;
 
 #[derive(Debug, Clone)]
 pub struct DownloadTx;
+
+#[derive(Debug, Clone)]
+pub struct WaitTx;
 
 #[derive(Debug, Clone)]
 pub struct NewTx;
@@ -52,11 +60,11 @@ impl From<TxEvent<ReceivedTx>> for TxEvent<DownloadTx> {
     }
 }
 
-impl From<TxEvent<DownloadTx>> for TxEvent<NewTx> {
+impl From<TxEvent<DownloadTx>> for TxEvent<WaitTx> {
     fn from(event: TxEvent<DownloadTx>) -> Self {
         TxEvent {
             tx: event.tx,
-            tx_type: NewTx,
+            tx_type: WaitTx,
         }
     }
 }
@@ -73,6 +81,15 @@ impl From<TxEvent<DownloadTx>> for Option<TxEvent<PropagateTx>> {
                 tx: event.tx,
                 tx_type: PropagateTx,
             }),
+        }
+    }
+}
+
+impl From<TxEvent<WaitTx>> for TxEvent<NewTx> {
+    fn from(event: TxEvent<WaitTx>) -> Self {
+        TxEvent {
+            tx: event.tx,
+            tx_type: NewTx,
         }
     }
 }
@@ -117,7 +134,7 @@ impl TxEvent<DownloadTx> {
         self,
         local_directory_path: &Path,
         http_peer_list: Vec<(SocketAddr, Option<u16>)>,
-    ) -> Result<(TxEvent<NewTx>, Option<TxEvent<PropagateTx>>), EventProcessError> {
+    ) -> Result<(TxEvent<WaitTx>, Option<TxEvent<PropagateTx>>), EventProcessError> {
         let http_client = reqwest::Client::new();
         let asset_file_list = self.tx.get_asset_list().map_err(|err| {
             EventProcessError::DownloadAssetError(format!(
@@ -143,7 +160,7 @@ impl TxEvent<DownloadTx> {
             .map_err(|err| {
                 EventProcessError::DownloadAssetError(format!("Execution error:{err}"))
             })?;
-        let newtx: TxEvent<NewTx> = self.clone().into();
+        let newtx: TxEvent<WaitTx> = self.clone().into();
         let propagate: Option<TxEvent<PropagateTx>> = self.into();
         Ok((newtx, propagate))
     }
@@ -175,6 +192,40 @@ impl TxEvent<PropagateTx> {
     }
 }
 
+impl TxEvent<WaitTx> {
+    pub async fn process_event(
+        self,
+        cache: &mut TXCache,
+        storage: &impl Storage,
+    ) -> Result<Vec<TxEvent<NewTx>>, EventProcessError> {
+        // Verify Tx'x parent is already present.
+        let new_txs = if let Some(parent) = self.tx.payload.get_parent_tx() {
+            if cache.is_tx_cached(parent)
+                || storage
+                    .get(parent)
+                    .await
+                    .map_err(|err| EventProcessError::StorageError(format!("{err}")))?
+                    .is_some()
+            {
+                let mut new_txs = cache.remove_children_txs(parent);
+                new_txs.push(self);
+                new_txs
+            } else {
+                //parent is missing add to waiting list
+                cache.add_wait_tx(*parent, self);
+                vec![]
+            }
+        } else {
+            //no parent always new Tx.
+            vec![self]
+        };
+
+        let ret = new_txs.into_iter().map(|tx| tx.into()).collect();
+
+        Ok(ret)
+    }
+}
+
 impl TxEvent<NewTx> {
     pub async fn process_event(
         self,
@@ -200,5 +251,40 @@ impl TxEvent<NewTx> {
             .send_new_tx(tx)
             .map_err(|err| EventProcessError::SaveTxError(format!("{err}")))
             .await
+    }
+}
+
+pub struct TXCache {
+    // List of Tx waiting for parent.let waiting_txs =
+    waiting_tx: HashMap<Hash, Vec<TxEvent<WaitTx>>>,
+    // Cache of the last saved Tx in the DB. To avoid to query the db for Tx.
+    cachedtx_for_verification: LruCache<Hash, WaitTx>,
+}
+
+impl TXCache {
+    pub fn new() -> Self {
+        let cachedtx_for_verification =
+            LruCache::new(std::num::NonZeroUsize::new(MAX_CACHED_TX_FOR_VERIFICATION).unwrap());
+        TXCache {
+            waiting_tx: HashMap::new(),
+            cachedtx_for_verification,
+        }
+    }
+
+    pub fn is_tx_cached(&self, hash: &Hash) -> bool {
+        self.cachedtx_for_verification.contains(hash)
+    }
+
+    pub fn add_cached_tx(&mut self, hash: Hash) {
+        self.cachedtx_for_verification.put(hash, WaitTx);
+    }
+
+    pub fn add_wait_tx(&mut self, parent: Hash, tx: TxEvent<WaitTx>) {
+        let waiting_txs = self.waiting_tx.entry(parent).or_insert(vec![]);
+        waiting_txs.push(tx);
+    }
+
+    pub fn remove_children_txs(&mut self, parent: &Hash) -> Vec<TxEvent<WaitTx>> {
+        self.waiting_tx.remove(parent).unwrap_or(vec![])
     }
 }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -279,7 +279,7 @@ pub struct TxCache {
     // List of Tx waiting for parent.let waiting_txs =
     waiting_tx: HashMap<Hash, (Vec<TxEvent<WaitTx>>, Instant)>,
     // Cache of the last saved Tx in the DB. To avoid to query the db for Tx.
-    cachedtx_for_verification: LruCache<Hash, WaitTx>,
+    cached_tx_for_verification: LruCache<Hash, WaitTx>,
     // Number of Waiting Tx that trigger the Tx eviction process.
     max_waiting_tx: usize,
     // Max time a Tx can wait in millisecond.
@@ -295,22 +295,22 @@ impl TxCache {
         )
     }
     pub fn build(cache_size: usize, max_waiting_tx: usize, max_waiting_time: u64) -> Self {
-        let cachedtx_for_verification =
+        let cached_tx_for_verification =
             LruCache::new(std::num::NonZeroUsize::new(cache_size).unwrap());
         TxCache {
             waiting_tx: HashMap::new(),
-            cachedtx_for_verification,
+            cached_tx_for_verification,
             max_waiting_tx,
             max_waiting_time: Duration::from_millis(max_waiting_time),
         }
     }
 
     pub fn is_tx_cached(&self, hash: &Hash) -> bool {
-        self.cachedtx_for_verification.contains(hash)
+        self.cached_tx_for_verification.contains(hash)
     }
 
     pub fn add_cached_tx(&mut self, hash: Hash) {
-        self.cachedtx_for_verification.put(hash, WaitTx);
+        self.cached_tx_for_verification.put(hash, WaitTx);
     }
 
     pub fn add_new_waiting_tx(&mut self, parent: Hash, tx: TxEvent<WaitTx>) {

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -296,12 +296,12 @@ impl TXCache {
     }
 
     pub fn add_new_waiting_tx(&mut self, parent: Hash, tx: TxEvent<WaitTx>) {
-        let waiting_txs = self.waiting_tx.entry(parent).or_insert(vec![]);
+        let waiting_txs = self.waiting_tx.entry(parent).or_default();
         waiting_txs.push(tx);
     }
 
     pub fn remove_waiting_children_txs(&mut self, parent: &Hash) -> Vec<TxEvent<WaitTx>> {
-        self.waiting_tx.remove(parent).unwrap_or(vec![])
+        self.waiting_tx.remove(parent).unwrap_or_default()
     }
 }
 
@@ -339,7 +339,7 @@ mod tests {
 
     fn new_proof_tx_event(parent: Hash) -> TxEvent<WaitTx> {
         let payload = Payload::Proof {
-            parent: parent,
+            parent,
             prover: Hash::default(),
             proof: vec![],
             files: vec![],
@@ -364,7 +364,7 @@ mod tests {
             state: Received::P2P,
         };
         TxEvent {
-            tx: tx,
+            tx,
             tx_type: WaitTx,
         }
     }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -483,7 +483,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_waittx_process_event() {
+    async fn test_wait_tx_process_event() {
         let db = TestDb(Mutex::new(HashMap::new()));
         // Set parameters to avoid wait tx eviction.
         let mut wait_tx_cache = TxCache::build(2, 10, 1000);

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -147,7 +147,7 @@ pub async fn spawn_event_loop(
     impl Stream<Item = Transaction<Validated>>,
 )> {
     let local_directory_path = Arc::new(local_directory_path);
-    //start http download manager
+    // Start http download manager
     let download_jh =
         download_manager::serve_files(bind_addr, http_download_port, local_directory_path.clone())
             .await?;
@@ -169,12 +169,12 @@ pub async fn spawn_event_loop(
                         //create new event with the Tx
                         let event: TxEvent<ReceivedTx> = tx.into();
 
-                        //process RcvTx(EventTx<SourceTxType>) event
+                        // Process RcvTx(EventTx<SourceTxType>) event
                         let http_peer_list = convert_peer_list_to_vec(&http_peer_list).await;
 
                         tracing::trace!("txvalidation receive event:{}", event.tx.hash.to_string());
 
-                        //process the receive event
+                        // Process the receive event
                         let validate_jh = tokio::spawn({
                             let p2p_sender = p2p_sender.clone();
                             let local_directory_path = local_directory_path.clone();
@@ -235,13 +235,13 @@ pub async fn spawn_event_loop(
                      }
                      Some(Ok((res, callback))) = validation_okresult_futures.next() =>  {
                         if let Some(callback) = callback {
-                            //forget the result because if the RPC connection is closed the send can fail.
+                            // Forget the result because if the RPC connection is closed the send can fail.
                             let _ = callback.send(res);
                         }
                      }
                      Some((res, callback)) = validation_errresult_futures.next() =>  {
                         if let Some(callback) = callback {
-                            //forget the result because if the RPC connection is closed the send can fail.
+                            // Forget the result because if the RPC connection is closed the send can fail.
                             let _ = callback.send(Err(res));
                         }
                      }

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -156,7 +156,7 @@ pub async fn spawn_event_loop(
     let p2p_stream = UnboundedReceiverStream::new(p2p_recv);
     let jh = tokio::spawn({
         let local_directory_path = local_directory_path.clone();
-        let mut wait_tx_cache = TXCache::new();
+        let mut wait_tx_cache = TXCache::new(MAX_CACHED_TX_FOR_VERIFICATION);
         let mut validated_txs_futures = FuturesUnordered::new();
         let mut validation_okresult_futures = FuturesUnordered::new();
         let mut validation_errresult_futures = FuturesUnordered::new();

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -35,8 +35,6 @@ pub trait ValidatedTxReceiver: Send + Sync {
     async fn send_new_tx(&mut self, tx: Transaction<Validated>) -> eyre::Result<()>;
 }
 
-const MAX_CACHED_TX_FOR_VERIFICATION: usize = 2;
-
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
 pub enum EventProcessError {
@@ -157,7 +155,7 @@ pub async fn spawn_event_loop(
     let p2p_stream = UnboundedReceiverStream::new(p2p_recv);
     let jh = tokio::spawn({
         let local_directory_path = local_directory_path.clone();
-        let mut wait_tx_cache = TXCache::new(MAX_CACHED_TX_FOR_VERIFICATION);
+        let mut wait_tx_cache = TXCache::new();
         let mut validated_txs_futures = FuturesUnordered::new();
         let mut validation_okresult_futures = FuturesUnordered::new();
         let mut validation_errresult_futures = FuturesUnordered::new();

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -130,6 +130,7 @@ impl TxEventSender<TxResultSender> {
 }
 
 //Main event processing loog.
+#[allow(clippy::too_many_arguments)]
 pub async fn spawn_event_loop(
     local_directory_path: PathBuf,
     bind_addr: SocketAddr,
@@ -210,9 +211,7 @@ pub async fn spawn_event_loop(
                                             let newtx_receiver = newtx_receiver.clone();
                                             async move {
                                                 for new_tx in new_tx_list {
-                                                    if let Err(err) = new_tx.process_event(&mut *(newtx_receiver.write().await)).await {
-                                                        return Err(err);
-                                                    }
+                                                   new_tx.process_event(&mut *(newtx_receiver.write().await)).await?;
                                                 }
                                                 Ok(())
                                             }

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -1,8 +1,11 @@
+use crate::mempool::Storage;
+use crate::txvalidation::event::TXCache;
 use crate::txvalidation::event::{ReceivedTx, TxEvent};
 use crate::types::{
     transaction::{Created, Received, Validated},
     Transaction,
 };
+use futures::stream::FuturesUnordered;
 use futures_util::Stream;
 use futures_util::TryFutureExt;
 use std::collections::HashMap;
@@ -12,12 +15,14 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::select;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 use tokio::sync::oneshot;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::StreamExt;
 
 pub mod acl;
 mod download_manager;
@@ -29,6 +34,8 @@ mod event;
 pub trait ValidatedTxReceiver: Send + Sync {
     async fn send_new_tx(&mut self, tx: Transaction<Validated>) -> eyre::Result<()>;
 }
+
+const MAX_CACHED_TX_FOR_VERIFICATION: usize = 2;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
@@ -48,6 +55,8 @@ pub enum EventProcessError {
     DownloadAssetError(String),
     #[error("Save Tx error: {0}")]
     SaveTxError(String),
+    #[error("Storage access error: {0}")]
+    StorageError(String),
     #[error("AclWhite list authenticate error: {0}")]
     AclWhiteListAuthError(#[from] acl::AclWhiteListError),
 }
@@ -131,6 +140,7 @@ pub async fn spawn_event_loop(
     mut rcv_tx_event_rx: UnboundedReceiver<(Transaction<Received>, Option<CallbackSender>)>,
     // Endpoint where validated transactions are sent to. Usually configured with Mempool.
     newtx_receiver: Arc<RwLock<dyn ValidatedTxReceiver + 'static>>,
+    storage: Arc<impl Storage + 'static>,
 ) -> eyre::Result<(
     JoinHandle<()>,
     // Output stream used to propagate transactions.
@@ -146,52 +156,98 @@ pub async fn spawn_event_loop(
     let p2p_stream = UnboundedReceiverStream::new(p2p_recv);
     let jh = tokio::spawn({
         let local_directory_path = local_directory_path.clone();
+        let mut wait_tx_cache = TXCache::new();
+        let mut validated_txs_futures = FuturesUnordered::new();
+        let mut validation_okresult_futures = FuturesUnordered::new();
+        let mut validation_errresult_futures = FuturesUnordered::new();
 
         async move {
-            while let Some((tx, callback)) = rcv_tx_event_rx.recv().await {
-                //create new event with the Tx
-                let event: TxEvent<ReceivedTx> = tx.into();
+            loop {
+                select! {
+                    // Execute Tx verification in a separate task.
+                    Some((tx, callback)) = rcv_tx_event_rx.recv() => {
+                        //create new event with the Tx
+                        let event: TxEvent<ReceivedTx> = tx.into();
 
-                //process RcvTx(EventTx<SourceTxType>) event
-                let http_peer_list = convert_peer_list_to_vec(&http_peer_list).await;
+                        //process RcvTx(EventTx<SourceTxType>) event
+                        let http_peer_list = convert_peer_list_to_vec(&http_peer_list).await;
 
-                tracing::trace!("txvalidation receive event:{}", event.tx.hash.to_string());
+                        tracing::trace!("txvalidation receive event:{}", event.tx.hash.to_string());
 
-                //process the receive event
-                tokio::spawn({
-                    let p2p_sender = p2p_sender.clone();
-                    let local_directory_path = local_directory_path.clone();
-                    let acl_whitelist = acl_whitelist.clone();
-                    let newtx_receiver = newtx_receiver.clone();
-                    async move {
-                        let res = event
-                            .process_event(acl_whitelist.as_ref())
-                            .and_then(|download_event| {
-                                download_event.process_event(&local_directory_path, http_peer_list)
-                            })
-                            .and_then(|(new_tx, propagate_tx)| async move {
-                                if let Some(propagate_tx) = propagate_tx {
-                                    propagate_tx.process_event(&p2p_sender).await?;
+                        //process the receive event
+                        let validate_jh = tokio::spawn({
+                            let p2p_sender = p2p_sender.clone();
+                            let local_directory_path = local_directory_path.clone();
+                            let acl_whitelist = acl_whitelist.clone();
+                            async move {
+                                event
+                                    .process_event(acl_whitelist.as_ref())
+                                    .and_then(|download_event| {
+                                        download_event.process_event(&local_directory_path, http_peer_list)
+                                    })
+                                    .and_then(|(wait_tx, propagate_tx)| async move {
+                                        if let Some(propagate_tx) = propagate_tx {
+                                            propagate_tx.process_event(&p2p_sender).await?;
+                                        }
+                                        Ok(wait_tx)
+                                    })
+                                    .await
+                            }
+                        });
+                        let fut = validate_jh
+                            .or_else(|err| async move {Err(EventProcessError::ValidateError(format!("Process execution error:{err}")))} )
+                            .and_then(|res| async move {Ok((res,callback))});
+                        validated_txs_futures.push(fut);
+                    }
+                    // Verify Tx parent and send to mempool all ready Tx.
+                    Some(Ok((wait_tx_res, callback))) = validated_txs_futures.next() =>  {
+                        match wait_tx_res {
+                            Ok(wait_tx) => {
+                               match wait_tx.process_event(&mut wait_tx_cache, storage.as_ref()).await {
+                                    Ok(new_tx_list) => {
+                                        //
+                                        let jh  = tokio::spawn({
+                                            let newtx_receiver = newtx_receiver.clone();
+                                            async move {
+                                                for new_tx in new_tx_list {
+                                                    if let Err(err) = new_tx.process_event(&mut *(newtx_receiver.write().await)).await {
+                                                        return Err(err);
+                                                    }
+                                                }
+                                                Ok(())
+                                            }
+                                        });
+                                        let fut = jh
+                                            .or_else(|err| async move {Err(EventProcessError::ValidateError(format!("Process execution error:{err}")))} )
+                                            .and_then(|res| async move {Ok((res,callback))});
+                                        validation_okresult_futures.push(fut);
+                                    }
+                                    Err(err) => {
+                                        validation_errresult_futures.push(futures::future::ready((err, callback)));
+                                    }
                                 }
-                                new_tx
-                                    .process_event(&mut *(newtx_receiver.write().await))
-                                    .await?;
 
-                                Ok(())
-                            })
-                            .await;
-                        //log the error if any error is return
-                        if let Err(ref err) = res {
-                            tracing::error!("An error occurs during Tx validation: {err}",);
+                            }
+                            Err(err)  => {
+                                validation_errresult_futures.push(futures::future::ready((err, callback)));
+                            }
                         }
-                        //send the execution result back if needed.
+                     }
+                     Some(Ok((res, callback))) = validation_okresult_futures.next() =>  {
                         if let Some(callback) = callback {
                             //forget the result because if the RPC connection is closed the send can fail.
                             let _ = callback.send(res);
                         }
-                    }
-                });
-            }
+                     }
+                     Some((res, callback)) = validation_errresult_futures.next() =>  {
+                        if let Some(callback) = callback {
+                            //forget the result because if the RPC connection is closed the send can fail.
+                            let _ = callback.send(Err(res));
+                        }
+                     }
+
+                } // End select!
+            } // End loop
         }
     });
     Ok((jh, p2p_stream))

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -193,6 +193,15 @@ impl std::fmt::Display for Payload {
 }
 
 impl Payload {
+    //return the parent tx associated to the payloas if any.
+    pub fn get_parent_tx(&self) -> Option<&Hash> {
+        match self {
+            Payload::Proof { parent, .. } => Some(parent),
+            Payload::ProofKey { parent, .. } => Some(parent),
+            Payload::Verification { parent, .. } => Some(parent),
+            _ => None,
+        }
+    }
     pub fn serialize_into(&self, buf: &mut Vec<u8>) {
         match self {
             Payload::Empty => {}

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -193,7 +193,7 @@ impl std::fmt::Display for Payload {
 }
 
 impl Payload {
-    //return the parent tx associated to the payloas if any.
+    // Return the parent tx associated to the payloads, if any.
     pub fn get_parent_tx(&self) -> Option<&Hash> {
         match self {
             Payload::Proof { parent, .. } => Some(parent),


### PR DESCRIPTION
A Child Tx must be executed after its parent if it has a parent Tx.
This order is not guaranteed by the current code and can easily arrive when Proof has a big file as input. The child verify Tx can be executed during the proof input file download.
After Tx verification, the Tx's parent, if it exists, is verified to be already validated.
To do that, the presence of the parent Tx in the db is verified. A cache is used to avoid Db query of the recent Tx.
If the parent is not found, the Tx is put in a waiting list.
When the parent arrives, the child Tx are removed from the waiting list and added to the mempool with the parent tx.

The process_event logic code is more complex because I wanted to avoid using a mutex for the cache, and we need to mix sync code (cache / waiting Tx verification) and async one.

I set it in draft because to be fully tested, the PE #136 must be merged to be able to test it with bigfile.