### PR TITLE
Correct file missing bug. Add file copy to virtfs before executing VM

### DIFF
--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -240,6 +240,27 @@ impl Scheduler {
                 }
             };
 
+            //copy Task file to VM workspace
+            //Validate that everything is ok before starting the task.
+            for file in task.files.iter() {
+                if let Err(err) = file
+                    .copy_file_for_vm_exe(&self.data_directory, task.tx)
+                    .await
+                {
+                    tracing::error!(
+                        "An error occurs during Tx:{} task file copy for VM execution {err}",
+                        task.tx
+                    );
+                    if let Err(err) = self.database.mark_tx_executed(&task.tx).await {
+                        tracing::error!(
+                            "failed to update transaction.executed => true - tx.hash: {}",
+                            task.tx
+                        );
+                    }
+                    continue;
+                }
+            }
+
             // Push the task into program's work queue.
             {
                 let mut state = self.state.lock().await;

--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -240,8 +240,8 @@ impl Scheduler {
                 }
             };
 
-            //copy Task file to VM workspace
-            //Validate that everything is ok before starting the task.
+            // Copy Task file to VM workspace
+            // Validate that everything is ok before starting the task.
             for file in task.files.iter() {
                 if let Err(err) = file
                     .copy_file_for_vm_exe(&self.data_directory, task.tx)

--- a/crates/node/src/vmm/vm_server.rs
+++ b/crates/node/src/vmm/vm_server.rs
@@ -4,7 +4,6 @@ use crate::types::Hash;
 use crate::types::Task;
 use async_trait::async_trait;
 use eyre::Result;
-use gevulot_node::types::file::TaskVmFile;
 use grpc::vm_service_server::VmService;
 use grpc::{TaskRequest, TaskResultResponse};
 use std::fmt::Debug;
@@ -159,15 +158,6 @@ impl VmService for VMServer {
                 "submit_result different Tx_hash from vm_id:{} and request result:{}",
                 tx_hash.to_string(),
                 request_tx_hash.to_string()
-            );
-        }
-
-        // Clean VM `/workspace` data.
-        let workspace_path = TaskVmFile::get_workspace_path(&self.file_data_dir, request_tx_hash);
-        if let Err(err) = std::fs::remove_dir_all(workspace_path) {
-            tracing::warn!(
-                "Execution workspace for Tx:{} didn't clean correctly because {err}",
-                tx_hash
             );
         }
 


### PR DESCRIPTION
The task's files weren't copied to the virtfs location before the VM execution.
I add this copy before the VM start to be sure the files are copied when the VM is started.
If the copy fails, the task and associated Tx are cancelled and marked as executed.

I think we should change how files are stored because there are several places depending on the file's Tx, and it creates useless complexity.
For example:
 * deploy tx: image file under /images/<file checksum>/<image name>.
 * proof Tx: input file under /<tx Hash>/<VM file path>: this path works directly when the Tx is executed because it's the Virtfs path of the file.
 * Tx output file are moved from Virtfs location: /<tx Hash>/workspace/<file VM path> to  /<new tx hash>/<file checksum>/<file_name>.
 * verify tx: input file under /<tx hash>/<file checksum>/<file_name>: these files need to be copied to virtfs localtion when the Tx is executed. It's the current PR update.

I think we should use:
 * for image: /images/<file checksum> I'll remove the image name to avoid name incompatibility with file system path.
 * /txfiles/<tx hash>/<file checksum>. The same, I'll remove the filename or path to avoid incompatibilities. These incompatibilities can be a vector of attack.
 * Virtfs path: /vmworkspace/<tx hash>/workspace
Filename in the path can ease the development. Perhaps we can define a dev mode where the filenames are added?

Currently, with the current file path definition, there's an issue that can arrive in a very particular case:
 * The input file of the proof Tx is also the output file of the tx.
 * This file is moved to the verifyTx path, so the proof Tx lose its input file.
 * Another node request the proof Tx input that is missing. The Tx fail on the other node.

Last I remove the <firtfs>/worplace cleanup because it can remove the proof fs input file.

So with this correction if works, but I think we should change the way file are managed. I can open an issue about it. There's already an issue about txfile root path for tx files that I've worked on.