### PR TITLE
Add support for optional program name on deploy

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -163,6 +163,8 @@ pub async fn run_deploy_command(
     name: String,
     prover: String,
     verifier: String,
+    prover_name: Option<String>,
+    verifier_name: Option<String>,
     prover_img_url: Option<String>,
     verifier_img_url: Option<String>,
     prover_reqs: Option<ResourceRequest>,
@@ -186,10 +188,16 @@ pub async fn run_deploy_command(
     let verifier_data: FileData = file_data.swap_remove(0);
 
     let mut prover_prg_data: ProgramMetadata = prover_data.into();
+    if prover_name.is_some() {
+        prover_prg_data.name = prover_name.unwrap()
+    };
     prover_prg_data.resource_requirements = prover_reqs;
     prover_prg_data.update_hash();
     let prover_prg_hash = prover_prg_data.hash;
     let mut verifier_prg_data: ProgramMetadata = verifier_data.into();
+    if verifier_name.is_some() {
+        verifier_prg_data.name = verifier_name.unwrap();
+    }
     verifier_prg_data.resource_requirements = verifier_reqs;
     verifier_prg_data.update_hash();
     let verifier_prg_hash = verifier_prg_data.hash;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,6 +32,7 @@ pub struct ArgConfiguration {
 }
 
 #[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 enum ConfCommands {
     /// Generate a private key file using --keyfile option.
     GenerateKey,
@@ -48,6 +49,12 @@ enum ConfCommands {
         /// file path containing the program image of the verifier to deploy or the hash  of the verifier image file (--verifier-img-url is mandatory in this case). If the file doesn't exist, the parameter is used as a hash.
         #[clap(short, long, value_name = "VERIFIER FILE or HASH")]
         verifier: String,
+        /// name of the prover.
+        #[clap(long, value_name = "PROVER NAME")]
+        prover_name: Option<String>,
+        /// name of the verifier.
+        #[clap(long, value_name = "VERIFIER NAME")]
+        verifier_name: Option<String>,
         /// url to get the prover image. If provided the prover will use this URL to get the prover image file. If not the cli tool starts a local HTTP server to serve the file to the node.
         #[clap(long = "proverimgurl", value_name = "PROVER URL")]
         prover_img_url: Option<String>,
@@ -189,6 +196,8 @@ async fn main() {
             name,
             prover,
             verifier,
+            prover_name,
+            verifier_name,
             prover_img_url,
             verifier_img_url,
             prover_cpus,
@@ -209,6 +218,8 @@ async fn main() {
                 name,
                 prover,
                 verifier,
+                prover_name,
+                verifier_name,
                 prover_img_url,
                 verifier_img_url,
                 prover_reqs,


### PR DESCRIPTION
When deploying prover and verifier, it can be useful to give it a descriptive name. This is displayed as a tag in the devnet dashboard.