### PR TITLE
Change tx root folder to txfiles

### DIFF
--- a/crates/node/src/txvalidation/download_manager.rs
+++ b/crates/node/src/txvalidation/download_manager.rs
@@ -30,7 +30,7 @@ pub async fn download_asset_file(
     tracing::info!("download_file:{asset_file:?} local_directory_path:{local_directory_path:?} local_relative_file_path:{local_relative_file_path:?} http_peer_list:{http_peer_list:?}");
 
     // Detect if the file already exist. If yes don't download.
-    if asset_file.exist(&local_relative_file_path).await {
+    if asset_file.exist(local_relative_file_path).await {
         tracing::trace!(
             "download_asset_file: File already exist, skip download: {:#?}",
             asset_file.get_save_path()
@@ -50,7 +50,7 @@ pub async fn download_asset_file(
                 .iter()
                 .filter_map(|(peer, port)| {
                     port.map(|port| {
-                        //use parse to create an URL, no new method.
+                        // Use parse to create an URL, no new method.
                         let mut url =
                             reqwest::Url::parse(&format!("{HTTP_SERVER_SCHEME}localhost")).unwrap(); //unwrap always succeed
                         url.set_ip_host(peer.ip()).unwrap(); //unwrap always succeed
@@ -84,7 +84,7 @@ pub async fn download_asset_file(
     };
 
     if resp.status() == reqwest::StatusCode::OK {
-        let file_path = local_directory_path.join(&local_relative_file_path);
+        let file_path = local_directory_path.join(local_relative_file_path);
         // Ensure any necessary subdirectories exists.
         if let Some(parent) = file_path.parent() {
             if let Ok(false) = tokio::fs::try_exists(parent).await {
@@ -92,15 +92,15 @@ pub async fn download_asset_file(
             }
         }
 
-        //create a tmp file during download.
-        //this way the file won't be available for download from the other nodes
-        //until it is completely written.
+        // Create a tmp file during download.
+        // This way the file won't be available for download from the other nodes
+        // until it is completely written.
         let mut tmp_file_path = file_path.clone();
         tmp_file_path.set_extension("tmp");
         let fd = tokio::fs::File::create(&tmp_file_path).await?;
         let mut fd = tokio::io::BufWriter::new(fd);
 
-        //create the Hasher to verify the Hash
+        // Create the Hasher to verify the Hash
         let mut hasher = blake3::Hasher::new();
 
         loop {
@@ -146,8 +146,8 @@ pub async fn download_asset_file(
     }
 }
 
-//start the local server and serve the specified file path.
-//Return the server task join handle.
+// Start the local server and serve the specified file path.
+// Return the server task join handle.
 pub async fn serve_files(
     mut bind_addr: SocketAddr,
     http_download_port: u16,
@@ -207,7 +207,7 @@ async fn server_process_file(
     let file = match tokio::fs::File::open(&file_path).await {
         Ok(file) => file,
         Err(_) => {
-            //try to see if the file is currently being updated.
+            // Try to see if the file is currently being updated.
             file_path.set_extension("tmp");
             let (status_code, message) = if file_path.as_path().exists() {
                 (

--- a/crates/node/src/txvalidation/download_manager.rs
+++ b/crates/node/src/txvalidation/download_manager.rs
@@ -40,7 +40,7 @@ pub async fn download_asset_file(
     let file_uri = asset_file.get_uri();
     let mut resp = match tokio::time::timeout(
         tokio::time::Duration::from_secs(5),
-        http_client.get(asset_file.file.url).send(),
+        http_client.get(&asset_file.url).send(),
     )
     .await
     {
@@ -72,13 +72,13 @@ pub async fn download_asset_file(
             }
             resp.ok_or(eyre!(
                 "Download no host found to download the file: {}",
-                asset_file.file.name
+                asset_file.name
             ))?
         }
         Err(err) => {
             return Err(eyre!(
                 "Download file: {:?}, request send timeout.",
-                asset_file.file.name
+                asset_file.name
             ));
         }
     };
@@ -113,13 +113,13 @@ pub async fn download_asset_file(
                 Ok(Err(_)) => {
                     return Err(eyre!(
                         "Download file: {:?}, connection timeout",
-                        asset_file.file.name
+                        asset_file.name
                     ));
                 }
                 Err(err) => {
                     return Err(eyre!(
                         "Download file: {:?}, http error:{err}",
-                        asset_file.file.name
+                        asset_file.name
                     ));
                 }
             }
@@ -127,11 +127,11 @@ pub async fn download_asset_file(
 
         fd.flush().await?;
         let checksum: crate::types::Hash = (&hasher.finalize()).into();
-        if checksum != asset_file.file.checksum {
+        if checksum != asset_file.checksum {
             Err(eyre!(
                 "download_file:{:?} bad checksum checksum:{checksum}  set_file.checksum:{}.",
-                asset_file.file.name,
-                asset_file.file.checksum
+                asset_file.name,
+                asset_file.checksum
             ))
         } else {
             //rename to original name
@@ -140,7 +140,7 @@ pub async fn download_asset_file(
     } else {
         Err(eyre!(
             "failed to download file: {:?} response status: {}",
-            asset_file.file.name,
+            asset_file.name,
             resp.status()
         ))
     }

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -29,7 +29,7 @@ mod download_manager;
 mod event;
 
 // `ValidatedTxReceiver` provides a simple trait to decouple event based
-// transaction handling from the execution part.
+// Transaction handling from the execution part.
 #[async_trait::async_trait]
 pub trait ValidatedTxReceiver: Send + Sync {
     async fn send_new_tx(&mut self, tx: Transaction<Validated>) -> eyre::Result<()>;
@@ -61,8 +61,8 @@ pub enum EventProcessError {
 
 pub type CallbackSender = oneshot::Sender<Result<(), EventProcessError>>;
 
-//Sending Tx interface.
-//Some marker type to define the sender source.
+// Sending Tx interface.
+// Some marker type to define the sender source.
 pub struct RpcSender;
 #[derive(Clone)]
 pub struct P2pSender;

--- a/crates/node/src/types/file.rs
+++ b/crates/node/src/types/file.rs
@@ -212,7 +212,7 @@ impl AssetFile {
                 checksum,
             } => {
                 //verify the url is valide.
-                reqwest::Url::parse(file_url)?;
+                reqwest::Url::parse(&file_url)?;
                 let mut file_name_path = Path::new(&file_name);
                 if file_name_path.is_absolute() {
                     file_name_path = file_name_path.strip_prefix("/").unwrap(); // Unwrap tested in `is_absolute()`.
@@ -290,11 +290,15 @@ impl TxFile<Output> {
 
     pub fn into_download_file(self, tx_hash: Hash) -> AssetFile {
         let relative_path = self.get_relatif_path(tx_hash);
-        let url = format!("{}/{}", self.url, relative_path.to_str().unwrap());
+        let url = format!(
+            "{}/{}",
+            self.url,
+            relative_path.to_str().unwrap().to_string()
+        );
 
         AssetFile {
             name: self.name,
-            file_path: relative_path,
+            file_path: relative_path.into(),
             url,
             checksum: self.checksum,
             verify_exist: true,

--- a/crates/node/src/types/file.rs
+++ b/crates/node/src/types/file.rs
@@ -212,7 +212,7 @@ impl AssetFile {
                 checksum,
             } => {
                 //verify the url is valide.
-                reqwest::Url::parse(&file_url)?;
+                reqwest::Url::parse(file_url)?;
                 let mut file_name_path = Path::new(&file_name);
                 if file_name_path.is_absolute() {
                     file_name_path = file_name_path.strip_prefix("/").unwrap(); // Unwrap tested in `is_absolute()`.
@@ -290,15 +290,11 @@ impl TxFile<Output> {
 
     pub fn into_download_file(self, tx_hash: Hash) -> AssetFile {
         let relative_path = self.get_relatif_path(tx_hash);
-        let url = format!(
-            "{}/{}",
-            self.url,
-            relative_path.to_str().unwrap().to_string()
-        );
+        let url = format!("{}/{}", self.url, relative_path.to_str().unwrap());
 
         AssetFile {
             name: self.name,
-            file_path: relative_path.into(),
+            file_path: relative_path,
             url,
             checksum: self.checksum,
             verify_exist: true,

--- a/crates/node/src/types/file.rs
+++ b/crates/node/src/types/file.rs
@@ -53,7 +53,6 @@ impl TaskVmFile<VmInput> {
         let to = PathBuf::new()
             .join(data_dir)
             .join(tx_file.get_relatif_path());
-        tracing::trace!("TaskVmFile copy_file_for_vm_exe  to:{to:?}",);
         if !tokio::fs::try_exists(&to).await.unwrap_or(false) {
             let from = PathBuf::new().join(data_dir).join(&self.extension.0);
             if let Some(parent) = to.parent() {
@@ -61,7 +60,7 @@ impl TaskVmFile<VmInput> {
                     .await
                     .map_err(|err| format!("mkdir {parent:?} fail:{err}"))?;
             }
-            tracing::trace!("TaskVmFile copy_file_for_vm_exe from:{from:?} to:{to:?}",);
+            tracing::debug!("TaskVmFile copy_file_for_vm_exe from:{from:?} to:{to:?}",);
             tokio::fs::copy(&from, &to)
                 .await
                 .map_err(|err| format!("copy file from:{from:?} to:{to:?} error:{err}"))?;
@@ -213,7 +212,7 @@ impl AssetFile {
                 checksum,
             } => {
                 //verify the url is valide.
-                reqwest::Url::parse(&file_url)?;
+                reqwest::Url::parse(file_url)?;
                 let mut file_name_path = Path::new(&file_name);
                 if file_name_path.is_absolute() {
                     file_name_path = file_name_path.strip_prefix("/").unwrap(); // Unwrap tested in `is_absolute()`.
@@ -238,26 +237,6 @@ impl AssetFile {
             }
         }
     }
-
-    // pub fn new(
-    //     name: String,
-    //     url: String,
-    //     checksum: Hash,
-    //     tx_hash: String,
-    //     path_prefix: String,
-    //     verify_exist: bool,
-    // ) -> Self {
-    //     AssetFile {
-    //         tx_hash,
-    //         verify_exist,
-    //         path_prefix,
-    //         file: DbFile {
-    //             name,
-    //             url,
-    //             checksum,
-    //         },
-    //     }
-    // }
 
     // Get relative File path for downloaded files to be saved on the node.
     pub fn get_save_path(&self) -> &Path {
@@ -311,15 +290,11 @@ impl TxFile<Output> {
 
     pub fn into_download_file(self, tx_hash: Hash) -> AssetFile {
         let relative_path = self.get_relatif_path(tx_hash);
-        let url = format!(
-            "{}/{}",
-            self.url,
-            relative_path.to_str().unwrap().to_string()
-        );
+        let url = format!("{}/{}", self.url, relative_path.to_str().unwrap());
 
         AssetFile {
             name: self.name,
-            file_path: relative_path.into(),
+            file_path: relative_path,
             url,
             checksum: self.checksum,
             verify_exist: true,

--- a/crates/node/src/types/file.rs
+++ b/crates/node/src/types/file.rs
@@ -317,7 +317,7 @@ pub struct Image(Hash);
 impl TxFile<Image> {
     pub fn try_from_prg_meta_data(value: &transaction::ProgramMetadata) -> Self {
         TxFile::build(
-            value.name.clone(),
+            value.image_file_name.clone(),
             value.image_file_url.clone(),
             value.image_file_checksum.clone().into(),
             Image(value.hash),

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -434,7 +434,6 @@ impl Transaction<Received> {
     }
 
     pub fn get_asset_list(&self) -> Result<Vec<AssetFile>> {
-        tracing::trace!("get_asset_list Transaction<Received:{self:?}");
         match &self.payload {
             transaction::Payload::Deploy {
                 prover, verifier, ..
@@ -449,7 +448,7 @@ impl Transaction<Received> {
                 .filter_map(|input| AssetFile::new_from_program_data(input, self.hash).transpose())
                 .collect(),
             Payload::Proof { files, .. } | Payload::Verification { files, .. } => {
-                //generated file during execution has already been moved. No Download.
+                // Generated file during execution has already been moved. No Download.
                 if self.state.is_from_tx_exec_result() {
                     Ok(vec![])
                 } else {

--- a/crates/node/src/vmm/qemu.rs
+++ b/crates/node/src/vmm/qemu.rs
@@ -1,3 +1,4 @@
+use crate::types::file::IMAGES_DIR;
 use async_trait::async_trait;
 use eyre::Result;
 use gevulot_node::types::file::TaskVmFile;
@@ -34,8 +35,6 @@ use crate::{
     types::{Hash, Program},
     vmm::ResourceRequest,
 };
-
-const IMAGES_DIR: &str = "images";
 
 impl VMId for u32 {
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
This version use the same folder for Virtfs and Tx proof input files. It avoids copying the files.

I change the AssetFile to only use the file path, and the path construction logic is done when the asset file is created.

VM_FILES_DIR is not implemented.
