### PR TITLE
When `ReousceError` happens, sheduler should try to `pick_task`

### DIFF
--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -229,7 +229,7 @@ impl Scheduler {
 
                             // Return the popped program_id back to pending queue.
                             state.pending_programs.push_back((tx_hash, program_id));
-                            continue 'SCHEDULING_LOOP;
+                            break;
                         }
                         Err(e) => {
                             tracing::warn!(


### PR DESCRIPTION
Assume we have 3 programs in `pending_programs`, we successfully start the 1st and 2nd programs, but fail to `start_program` 3rd, the logic should be continue to `pick_task`, right?

Please correct me if I was wrong.