### PR TITLE
correct Mac build by adding a common crate to share common declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,9 +1184,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gevulot-common"
+version = "0.1.0"
+
+[[package]]
 name = "gevulot-e2e-test-programs"
 version = "0.1.0"
 dependencies = [
+ "gevulot-common",
  "gevulot-shim",
 ]
 
@@ -1226,6 +1231,7 @@ dependencies = [
  "eyre",
  "futures",
  "futures-util",
+ "gevulot-common",
  "gevulot-shim",
  "hex",
  "home",
@@ -1272,6 +1278,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "blake3",
+ "gevulot-common",
  "prost 0.11.9",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,12 @@ exclude = [
   "prover"
 ]
 members = [
-  "crates/node",
+  "crates/common",
   "crates/cli",
+  "crates/node",
   "crates/shim",
   "crates/shim-ffi",
   "crates/tests/test-programs",
-  "crates/tests/e2e-tests",
+  "crates/tests/e2e-tests", "crates/common",
 ]
 resolver = "2"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "gevulot-common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,0 +1,2 @@
+pub const WORKSPACE_PATH: &str = "/workspace";
+pub const WORKSPACE_NAME: &str = "workspace";

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -11,6 +11,7 @@ blake3 = "1.5"
 chrono = { version = "0.4", features = [ "serde" ] }
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 eyre = "0.6.8"
+gevulot-common = { path = "../common" }
 hex = "0.4"
 jsonrpsee = { version = "0.20", features = [ "client", "server" ] }
 libsecp256k1 = "0.7"
@@ -32,7 +33,7 @@ clap = { version = "4", features = ["derive", "env", "string"], optional = true 
 console-subscriber = { version = "0.2", optional = true }
 futures = { version = "0.3.30", optional = true }
 futures-util = { version = "0.3", features = [ "io" ], optional = true }
-gevulot-shim = { path = "../shim", default-features = false }
+gevulot-shim = { path = "../shim", default-features = false, optional = true }
 home = { version = "0.5", optional = true}
 http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1", features = ["full"], optional = true }
@@ -64,6 +65,7 @@ node-binary = [
   "futures",
   "futures-util",
   "home",
+  "gevulot-shim",
   "http-body-util",
   "hyper",
   "hyper-util",

--- a/crates/node/src/types/file.rs
+++ b/crates/node/src/types/file.rs
@@ -30,7 +30,7 @@ impl TaskVmFile<()> {
             .join(data_directory)
             .join(VM_FILES_DIR)
             .join(tx_hash.to_string())
-            .join(gevulot_shim::WORKSPACE_NAME)
+            .join(gevulot_common::WORKSPACE_NAME)
     }
 }
 

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 anyhow = "1"
 async-stream = "0.3.5"
 blake3 = "1.5"
+gevulot-common = { path = "../common" }
 prost = "0.11"
 tokio = { version = "1.0", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-stream = "0.1"

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -19,9 +19,6 @@ mod grpc {
 /// present in /proc/mounts.
 const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub const WORKSPACE_PATH: &str = "/workspace";
-pub const WORKSPACE_NAME: &str = "workspace";
-
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 pub type TaskId = String;
 
@@ -210,7 +207,7 @@ fn mount_present(mount_point: &str) -> Result<bool> {
 /// run function takes `callback` that is invoked with executable `Task` and
 /// which is expected to return `TaskResult`.
 pub fn run(callback: impl Fn(Task) -> Result<TaskResult>) -> Result<()> {
-    let mut client = GRPCClient::new(8080, WORKSPACE_PATH)?;
+    let mut client = GRPCClient::new(8080, gevulot_common::WORKSPACE_PATH)?;
 
     loop {
         let task = match client.get_task() {

--- a/crates/tests/test-programs/Cargo.toml
+++ b/crates/tests/test-programs/Cargo.toml
@@ -15,3 +15,4 @@ path = "src/verifier.rs"
 
 [dependencies]
 gevulot-shim = { path = "../../shim" }
+gevulot-common = { path = "../../common" }

--- a/crates/tests/test-programs/src/prover.rs
+++ b/crates/tests/test-programs/src/prover.rs
@@ -1,4 +1,4 @@
-use gevulot_shim::WORKSPACE_PATH;
+use gevulot_common::WORKSPACE_PATH;
 use gevulot_shim::{Task, TaskResult};
 use std::fs;
 

--- a/crates/tests/test-programs/src/verifier.rs
+++ b/crates/tests/test-programs/src/verifier.rs
@@ -1,4 +1,4 @@
-use gevulot_shim::WORKSPACE_PATH;
+use gevulot_common::WORKSPACE_PATH;
 use gevulot_shim::{Task, TaskResult};
 use std::fs;
 


### PR DESCRIPTION
Add the common crate to avoid to build shim crate when building node::type::files.rs because of the share const WORKSPACE_PATH.

Start to put common data/function/struct in an independent crate.

@teempai, it builds on my Mac. You can test. Go in crates/cli and cargo run