### PR TITLE
Add command to print public key of a keyfile

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,7 @@ use gevulot_node::types::Hash;
 use gevulot_node::types::TransactionTree;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use libsecp256k1::PublicKey;
 
 #[derive(Parser, Debug)]
 #[clap(author = "Gevulot Team", version, about, long_about = None)]
@@ -195,15 +196,17 @@ async fn main() {
             Err(err) => println!("Error during key file creation:{err}"),
         },
         ConfCommands::PrintPublicKey => {
-            let key = gevulot_cli::keyfile::read_key_file(&args.keyfile);
-            match PublicKey::from_secret_key(&key) {
-                Ok(pubkey) => println!(
-                    "Extracted pubkey:{}",
-                    hex::encode(pubkey.serialize())
-                ),
+            match gevulot_cli::keyfile::read_key_file(&args.keyfile) {
+                Ok(key) => {
+                    let pubkey = PublicKey::from_secret_key(&key);
+                    return println!(
+                        "Extracted pubkey:{}",
+                        hex::encode(pubkey.serialize())
+                    )
+                },
                 Err(err) => println!("Error during key file access:{err}"),
             }
-        },
+        }
         ConfCommands::Deploy {
             name,
             prover,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -36,6 +36,8 @@ pub struct ArgConfiguration {
 enum ConfCommands {
     /// Generate a private key file using --keyfile option.
     GenerateKey,
+    /// Print a public key using --keyfile option.
+    PrintPublicKey,
 
     /// Deploy prover and verifier.
     #[command(arg_required_else_help = true)]
@@ -191,6 +193,13 @@ async fn main() {
                 args.keyfile.to_str().unwrap_or("")
             ),
             Err(err) => println!("Error during key file creation:{err}"),
+        },
+        ConfCommands::PrintPublicKey => match gevulot_cli::keyfile::read_key_file(&args.keyfile) {
+            Ok(pubkey) => println!(
+                "Extracted pubkey:{}",
+                hex::encode(pubkey.serialize())
+            ),
+            Err(err) => println!("Error during key file access:{err}"),
         },
         ConfCommands::Deploy {
             name,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -194,12 +194,15 @@ async fn main() {
             ),
             Err(err) => println!("Error during key file creation:{err}"),
         },
-        ConfCommands::PrintPublicKey => match gevulot_cli::keyfile::read_key_file(&args.keyfile) {
-            Ok(pubkey) => println!(
-                "Extracted pubkey:{}",
-                hex::encode(pubkey.serialize())
-            ),
-            Err(err) => println!("Error during key file access:{err}"),
+        ConfCommands::PrintPublicKey => {
+            let key = gevulot_cli::keyfile::read_key_file(&args.keyfile);
+            match PublicKey::from_secret_key(&key) {
+                Ok(pubkey) => println!(
+                    "Extracted pubkey:{}",
+                    hex::encode(pubkey.serialize())
+                ),
+                Err(err) => println!("Error during key file access:{err}"),
+            }
         },
         ConfCommands::Deploy {
             name,


### PR DESCRIPTION
For easy debugging, you can print the public key associated with a specific keyfile (useful for devnet especially to figure out which key you registered in case you generated several)