### PR TITLE
add watchdog http server

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -129,11 +129,11 @@ pub struct Config {
 
     #[arg(
         long,
-        long_help = "Watchdog listen address",
-        env = "GEVULOT_WATCHDOG_LISTEN_ADDR",
+        long_help = "Healthcheck listen address",
+        env = "GEVULOT_HEALTHCHECK_LISTEN_ADDR",
         default_value = "127.0.0.1:8888"
     )]
-    pub http_watchdog_listen_addr: SocketAddr,
+    pub http_healthcheck_listen_addr: SocketAddr,
 }
 
 #[derive(Debug, Args)]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -129,11 +129,11 @@ pub struct Config {
 
     #[arg(
         long,
-        long_help = "Healthcheck listen address",
-        env = "GEVULOT_HEALTHCHECK_LISTEN_ADDR",
+        long_help = "Watchdog listen address",
+        env = "GEVULOT_WATCHDOG_LISTEN_ADDR",
         default_value = "127.0.0.1:8888"
     )]
-    pub http_healthcheck_listen_addr: SocketAddr,
+    pub http_watchdog_listen_addr: SocketAddr,
 }
 
 #[derive(Debug, Args)]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -126,6 +126,14 @@ pub struct Config {
 
     #[arg(long, long_help = "GPU PCI devices", env = "GEVULOT_GPU_DEVICES")]
     pub gpu_devices: Option<String>,
+
+    #[arg(
+        long,
+        long_help = "Watchdog listen address",
+        env = "GEVULOT_WATCHDOG_LISTEN_ADDR",
+        default_value = "127.0.0.1:8888"
+    )]
+    pub http_watchdog_listen_addr: SocketAddr,
 }
 
 #[derive(Debug, Args)]

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -211,7 +211,7 @@ async fn run(config: Arc<Config>) -> Result<()> {
     let new_validated_tx_receiver: Arc<RwLock<dyn ValidatedTxReceiver>> = if !config.no_execution {
         let mempool = Arc::new(RwLock::new(Mempool::new(database.clone()).await?));
         let scheduler_watchdog_sender =
-            watchdog::start_watchdog(config.http_watchdog_listen_addr).await?;
+            watchdog::start_watchdog(config.http_healthcheck_listen_addr).await?;
         let scheduler = scheduler::start_scheduler(
             config.clone(),
             database.clone(),

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -37,6 +37,7 @@ mod scheduler;
 mod storage;
 mod txvalidation;
 mod vmm;
+mod watchdog;
 mod workflow;
 
 use mempool::Mempool;
@@ -209,7 +210,8 @@ async fn run(config: Arc<Config>) -> Result<()> {
     //To show to idea. Should use your config definition
     let new_validated_tx_receiver: Arc<RwLock<dyn ValidatedTxReceiver>> = if !config.no_execution {
         let mempool = Arc::new(RwLock::new(Mempool::new(database.clone()).await?));
-
+        let scheduler_watchdog_sender =
+            watchdog::start_watchdog(config.http_watchdog_listen_addr).await?;
         let scheduler = scheduler::start_scheduler(
             config.clone(),
             database.clone(),
@@ -220,7 +222,7 @@ async fn run(config: Arc<Config>) -> Result<()> {
         .await;
 
         // Run Scheduler in its own task.
-        tokio::spawn(async move { scheduler.run().await });
+        tokio::spawn(async move { scheduler.run(scheduler_watchdog_sender).await });
         mempool
     } else {
         struct ArchiveMempool(Arc<Database>);

--- a/crates/node/src/rpc_server/mod.rs
+++ b/crates/node/src/rpc_server/mod.rs
@@ -447,6 +447,7 @@ mod tests {
             mem_gb: None,
             gpu_devices: None,
             http_download_port: 0,
+            http_watchdog_listen_addr: "127.0.0.1:8888".parse().unwrap(),
         });
 
         let db = Arc::new(Database::new(&cfg.db_url).await.unwrap());

--- a/crates/node/src/rpc_server/mod.rs
+++ b/crates/node/src/rpc_server/mod.rs
@@ -447,7 +447,7 @@ mod tests {
             mem_gb: None,
             gpu_devices: None,
             http_download_port: 0,
-            http_watchdog_listen_addr: "127.0.0.1:8888".parse().unwrap(),
+            http_healthcheck_listen_addr: "127.0.0.1:8888".parse().unwrap(),
         });
 
         let db = Arc::new(Database::new(&cfg.db_url).await.unwrap());

--- a/crates/node/src/watchdog/mod.rs
+++ b/crates/node/src/watchdog/mod.rs
@@ -1,0 +1,240 @@
+use eyre::Result;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use tokio::time::Duration;
+
+pub const GRACEFULL_SIGNAL_COUNTER_LIMIT: usize = 20;
+pub const SCHEDULER_HEATH_SIGNAL_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
+
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
+pub enum HealthCheckSignal {
+    SchedulerLoopOk,
+    SchedulerMempoolLen(usize),
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
+enum WatchDogState {
+    Alive,
+    Graceful,
+    Critical,
+}
+
+impl From<WatchDogState> for StatusCode {
+    fn from(state: WatchDogState) -> Self {
+        match state {
+            WatchDogState::Alive => StatusCode::OK,
+            WatchDogState::Graceful => StatusCode::NO_CONTENT,
+            WatchDogState::Critical => StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+}
+
+pub async fn start_watchdog(bind_addr: SocketAddr) -> Result<mpsc::Sender<HealthCheckSignal>> {
+    let (scheduler_health_tx, scheduler_health_rx) = mpsc::channel::<HealthCheckSignal>(100);
+    let watchdog_state = Arc::new(Mutex::new(WatchDogState::Alive));
+    tokio::spawn({
+        let watchdog_state = watchdog_state.clone();
+        async move {
+            run_watchdog(
+                GRACEFULL_SIGNAL_COUNTER_LIMIT,
+                SCHEDULER_HEATH_SIGNAL_TIMEOUT_MILLI,
+                watchdog_state,
+                scheduler_health_rx,
+            )
+            .await;
+        }
+    });
+
+    serve_files(bind_addr, watchdog_state).await?;
+    Ok(scheduler_health_tx)
+}
+
+async fn run_watchdog(
+    gracefull_signal_counter_limit: usize,
+    scheduler_heath_signal_timeout: Duration,
+    watchdog_state: Arc<Mutex<WatchDogState>>,
+    mut scheduler_health_rx: mpsc::Receiver<HealthCheckSignal>,
+) {
+    let mut scheduler_state = (true, true, true);
+
+    let mut timout_counter = 0;
+
+    loop {
+        let mut new_state = scheduler_state;
+        match timeout(scheduler_heath_signal_timeout, scheduler_health_rx.recv()).await {
+            Ok(res) => {
+                //The scheduler signal is alive
+                timout_counter = 0;
+                new_state.2 = true;
+                match res {
+                    Some(msg) => match msg {
+                        HealthCheckSignal::SchedulerLoopOk => new_state.0 = true,
+                        HealthCheckSignal::SchedulerMempoolLen(len) => new_state.1 = len == 0,
+                    },
+                    None => {
+                        tracing::error!(
+                                    "Scheduler Health channel error, Health channel closed. Stop health check."
+                                );
+                        //Alone receiver get message
+                        (_, scheduler_health_rx) = tokio::sync::mpsc::channel(1);
+                        new_state.2 = false;
+                    }
+                }
+            }
+            Err(_) => {
+                tracing::error!("Scheduler Health signal Timeout, no health signal available.");
+                timout_counter += 1;
+                if timout_counter >= gracefull_signal_counter_limit {
+                    new_state.2 = false;
+                }
+            }
+        }
+
+        let state_changed = new_state != scheduler_state;
+        scheduler_state = new_state;
+
+        //update watchdog state
+        if state_changed {
+            let mut watchdog_state = watchdog_state.lock().await;
+            if !scheduler_state.0 || !scheduler_state.1 {
+                tracing::warn!(
+                    "watchdog detect critical state loop:{} mempool:{}",
+                    scheduler_state.0,
+                    scheduler_state.1
+                );
+                *watchdog_state = WatchDogState::Critical;
+            } else if !scheduler_state.2 {
+                tracing::warn!("watchdog detect Graceful issue.");
+                *watchdog_state = WatchDogState::Graceful;
+            } else {
+                *watchdog_state = WatchDogState::Alive;
+            }
+        }
+    }
+}
+
+// Start the local server and serve the watch dog requert.
+// WatchDogState::Alive => 200
+// WatchDogState::Graceful => 204
+// WatchDogState::Critical => 503
+async fn serve_files(
+    bind_addr: SocketAddr,
+    watchdog_state: Arc<Mutex<WatchDogState>>,
+) -> Result<()> {
+    let listener = TcpListener::bind(bind_addr).await?;
+
+    tokio::spawn({
+        async move {
+            tracing::info!(
+                "Watchdog listening for http at {}",
+                listener
+                    .local_addr()
+                    .expect("http listener's local address")
+            );
+
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _from)) => {
+                        let io = TokioIo::new(stream);
+                        tokio::task::spawn({
+                            let watchdog_state = watchdog_state.clone();
+                            async move {
+                                if let Err(err) = http1::Builder::new()
+                                    .serve_connection(
+                                        io,
+                                        service_fn(|_| {
+                                            let watchdog_state = watchdog_state.clone();
+                                            async move {
+                                                let status: StatusCode =
+                                                    (*watchdog_state.lock().await).into();
+                                                Response::builder()
+                                                    .status(status)
+                                                    .body(String::new())
+                                            }
+                                        }),
+                                    )
+                                    .await
+                                {
+                                    tracing::error!("Error serving watchdog connection: {err}.");
+                                }
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        tracing::error!("Error during node connection to file http server:{err}");
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn test_watchdog() {
+        let (scheduler_health_tx, scheduler_health_rx) = mpsc::channel::<HealthCheckSignal>(100);
+        let watchdog_state = Arc::new(Mutex::new(WatchDogState::Alive));
+        tokio::spawn({
+            let watchdog_state = watchdog_state.clone();
+            async move {
+                run_watchdog(
+                    2,
+                    Duration::from_millis(100),
+                    watchdog_state,
+                    scheduler_health_rx,
+                )
+                .await;
+            }
+        });
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerLoopOk)
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerMempoolLen(0))
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerMempoolLen(1))
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(WatchDogState::Critical, *watchdog_state.lock().await);
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerMempoolLen(0))
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+        sleep(Duration::from_millis(150)).await;
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+        sleep(Duration::from_millis(100)).await;
+        assert_eq!(WatchDogState::Graceful, *watchdog_state.lock().await);
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerLoopOk)
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+    }
+}

--- a/crates/node/src/watchdog/mod.rs
+++ b/crates/node/src/watchdog/mod.rs
@@ -13,8 +13,8 @@ use tokio::time::timeout;
 use tokio::time::Duration;
 
 pub const GRACEFULL_SIGNAL_COUNTER_LIMIT: usize = 20;
-pub const SCHEDULER_HEALTH_SIGNAL_TIMEOUT_MILLIS: Duration = Duration::from_millis(1000);
-pub const NO_LOOP_DETECT_TIMEOUT_MILLIS: Duration = Duration::from_millis(1000);
+pub const SCHEDULER_HEATH_SIGNAL_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
+pub const NO_LOOP_DETECT_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
 
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub enum HealthCheckSignal {
@@ -61,8 +61,8 @@ pub async fn start_watchdog(bind_addr: SocketAddr) -> Result<mpsc::Sender<Health
 }
 
 async fn run_watchdog(
-    graceful_signal_counter_limit: usize,
-    scheduler_health_signal_timeout: Duration,
+    gracefull_signal_counter_limit: usize,
+    scheduler_heath_signal_timeout: Duration,
     no_loop_detect_timeout: Duration,
     watchdog_state: Arc<Mutex<WatchDogState>>,
     mut scheduler_health_rx: mpsc::Receiver<HealthCheckSignal>,
@@ -73,7 +73,7 @@ async fn run_watchdog(
     let mut no_loop_detect_timer = tokio::time::interval(no_loop_detect_timeout);
     let mut see_scheduler_loop_ok = true;
 
-    let mut timeout_counter = 0;
+    let mut timout_counter = 0;
 
     loop {
         let mut new_state = scheduler_state;
@@ -145,7 +145,7 @@ async fn run_watchdog(
 // WatchDogState::Alive => 200
 // WatchDogState::Graceful => 204
 // WatchDogState::Critical => 503
-async fn serve_healthcheck(
+async fn serve_files(
     bind_addr: SocketAddr,
     watchdog_state: Arc<Mutex<WatchDogState>>,
 ) -> Result<()> {

--- a/crates/node/src/watchdog/mod.rs
+++ b/crates/node/src/watchdog/mod.rs
@@ -13,8 +13,8 @@ use tokio::time::timeout;
 use tokio::time::Duration;
 
 pub const GRACEFULL_SIGNAL_COUNTER_LIMIT: usize = 20;
-pub const SCHEDULER_HEATH_SIGNAL_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
-pub const NO_LOOP_DETECT_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
+pub const SCHEDULER_HEALTH_SIGNAL_TIMEOUT_MILLIS: Duration = Duration::from_millis(1000);
+pub const NO_LOOP_DETECT_TIMEOUT_MILLIS: Duration = Duration::from_millis(1000);
 
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub enum HealthCheckSignal {
@@ -61,8 +61,8 @@ pub async fn start_watchdog(bind_addr: SocketAddr) -> Result<mpsc::Sender<Health
 }
 
 async fn run_watchdog(
-    gracefull_signal_counter_limit: usize,
-    scheduler_heath_signal_timeout: Duration,
+    graceful_signal_counter_limit: usize,
+    scheduler_health_signal_timeout: Duration,
     no_loop_detect_timeout: Duration,
     watchdog_state: Arc<Mutex<WatchDogState>>,
     mut scheduler_health_rx: mpsc::Receiver<HealthCheckSignal>,
@@ -73,7 +73,7 @@ async fn run_watchdog(
     let mut no_loop_detect_timer = tokio::time::interval(no_loop_detect_timeout);
     let mut see_scheduler_loop_ok = true;
 
-    let mut timout_counter = 0;
+    let mut timeout_counter = 0;
 
     loop {
         let mut new_state = scheduler_state;
@@ -145,7 +145,7 @@ async fn run_watchdog(
 // WatchDogState::Alive => 200
 // WatchDogState::Graceful => 204
 // WatchDogState::Critical => 503
-async fn serve_files(
+async fn serve_healthcheck(
     bind_addr: SocketAddr,
     watchdog_state: Arc<Mutex<WatchDogState>>,
 ) -> Result<()> {

--- a/crates/node/src/watchdog/mod.rs
+++ b/crates/node/src/watchdog/mod.rs
@@ -83,7 +83,7 @@ async fn run_watchdog(
                         tracing::error!(
                                     "Scheduler Health channel error, Health channel closed. Stop health check."
                                 );
-                        //Alone receiver get message
+                        // Alone receiver won't get any message. recv always timeout.
                         (_, scheduler_health_rx) = tokio::sync::mpsc::channel(1);
                         new_state.2 = false;
                     }

--- a/crates/node/src/watchdog/mod.rs
+++ b/crates/node/src/watchdog/mod.rs
@@ -6,6 +6,7 @@ use hyper_util::rt::TokioIo;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::select;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -13,6 +14,7 @@ use tokio::time::Duration;
 
 pub const GRACEFULL_SIGNAL_COUNTER_LIMIT: usize = 20;
 pub const SCHEDULER_HEATH_SIGNAL_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
+pub const NO_LOOP_DETECT_TIMEOUT_MILLI: Duration = Duration::from_millis(1000);
 
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub enum HealthCheckSignal {
@@ -46,6 +48,7 @@ pub async fn start_watchdog(bind_addr: SocketAddr) -> Result<mpsc::Sender<Health
             run_watchdog(
                 GRACEFULL_SIGNAL_COUNTER_LIMIT,
                 SCHEDULER_HEATH_SIGNAL_TIMEOUT_MILLI,
+                NO_LOOP_DETECT_TIMEOUT_MILLI,
                 watchdog_state,
                 scheduler_health_rx,
             )
@@ -60,40 +63,57 @@ pub async fn start_watchdog(bind_addr: SocketAddr) -> Result<mpsc::Sender<Health
 async fn run_watchdog(
     gracefull_signal_counter_limit: usize,
     scheduler_heath_signal_timeout: Duration,
+    no_loop_detect_timeout: Duration,
     watchdog_state: Arc<Mutex<WatchDogState>>,
     mut scheduler_health_rx: mpsc::Receiver<HealthCheckSignal>,
 ) {
     let mut scheduler_state = (true, true, true);
 
+    // Define a timer to detect when the mempool pick_task is never call but the loop is working.
+    let mut no_loop_detect_timer = tokio::time::interval(no_loop_detect_timeout);
+    let mut see_scheduler_loop_ok = true;
+
     let mut timout_counter = 0;
 
     loop {
         let mut new_state = scheduler_state;
-        match timeout(scheduler_heath_signal_timeout, scheduler_health_rx.recv()).await {
-            Ok(res) => {
-                //The scheduler signal is alive
-                timout_counter = 0;
-                new_state.2 = true;
-                match res {
-                    Some(msg) => match msg {
-                        HealthCheckSignal::SchedulerLoopOk => new_state.0 = true,
-                        HealthCheckSignal::SchedulerMempoolLen(len) => new_state.1 = len == 0,
-                    },
-                    None => {
-                        tracing::error!(
-                                    "Scheduler Health channel error, Health channel closed. Stop health check."
-                                );
-                        // Alone receiver won't get any message. recv always timeout.
-                        (_, scheduler_health_rx) = tokio::sync::mpsc::channel(1);
-                        new_state.2 = false;
+        select! {
+             _ = no_loop_detect_timer.tick() => {
+                // No loop ok since last call. Set scheduler loop issue
+                if !see_scheduler_loop_ok {
+                    new_state.0 = false
+                }
+                see_scheduler_loop_ok = false;
+             }
+            res = timeout(scheduler_heath_signal_timeout, scheduler_health_rx.recv()) => match res {
+                Ok(res) => {
+                    //The scheduler signal is alive
+                    timout_counter = 0;
+                    new_state.2 = true;
+                    match res {
+                        Some(msg) => match msg {
+                            HealthCheckSignal::SchedulerLoopOk => {
+                                see_scheduler_loop_ok = true;
+                                new_state.0 = true
+                            },
+                            HealthCheckSignal::SchedulerMempoolLen(len) => new_state.1 = len == 0,
+                        },
+                        None => {
+                            tracing::error!(
+                                        "Scheduler Health channel error, Health channel closed. Stop health check."
+                                    );
+                            // Alone receiver won't get any message. recv always timeout.
+                            (_, scheduler_health_rx) = tokio::sync::mpsc::channel(1);
+                            new_state.2 = false;
+                        }
                     }
                 }
-            }
-            Err(_) => {
-                tracing::error!("Scheduler Health signal Timeout, no health signal available.");
-                timout_counter += 1;
-                if timout_counter >= gracefull_signal_counter_limit {
-                    new_state.2 = false;
+                Err(_) => {
+                    tracing::error!("Scheduler Health signal Timeout, no health signal available.");
+                    timout_counter += 1;
+                    if timout_counter >= gracefull_signal_counter_limit {
+                        new_state.2 = false;
+                    }
                 }
             }
         }
@@ -195,6 +215,7 @@ mod tests {
                 run_watchdog(
                     2,
                     Duration::from_millis(100),
+                    Duration::from_millis(300),
                     watchdog_state,
                     scheduler_health_rx,
                 )
@@ -220,6 +241,12 @@ mod tests {
             .unwrap();
         sleep(Duration::from_millis(20)).await;
         assert_eq!(WatchDogState::Critical, *watchdog_state.lock().await);
+        //reset loop no detect time
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerLoopOk)
+            .await
+            .unwrap();
+        //set state to Alive.
         scheduler_health_tx
             .send(HealthCheckSignal::SchedulerMempoolLen(0))
             .await
@@ -230,6 +257,16 @@ mod tests {
         assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
         sleep(Duration::from_millis(100)).await;
         assert_eq!(WatchDogState::Graceful, *watchdog_state.lock().await);
+        scheduler_health_tx
+            .send(HealthCheckSignal::SchedulerMempoolLen(0))
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(WatchDogState::Alive, *watchdog_state.lock().await);
+        // Detect no loop
+        sleep(Duration::from_millis(350)).await;
+        assert_eq!(WatchDogState::Critical, *watchdog_state.lock().await);
+        // Return to normal state.
         scheduler_health_tx
             .send(HealthCheckSignal::SchedulerLoopOk)
             .await


### PR DESCRIPTION
Add a http server that return the codes:
 *  Alive => StatusCode::OK (200)
 * Graceful => StatusCode::NO_CONTENT (204)
 * Critical => StatusCode::SERVICE_UNAVAILABLE (503)

2 signals are implemented:
 * the scheduler loop doesn't run
 * the mempool has more than 0 Tx after pooling.

Add a timer to detect that the mempool pick a task is not called after a certain time.
