### PR TITLE
rpc_server: `send_transaction` returns more specific error details

### DIFF
--- a/crates/node/src/rpc_server/mod.rs
+++ b/crates/node/src/rpc_server/mod.rs
@@ -91,7 +91,7 @@ async fn send_transaction(params: Params<'static>, ctx: Arc<Context>) -> RpcResp
     if let Err(err) = ctx.tx_sender.send_tx(tx).await {
         tracing::error!("failed to persist transaction: {}", err);
         return RpcResponse::Err(RpcError::InvalidRequest(
-            "failed to persist transaction".to_string(),
+            format!("failed to persist transaction: {:#}", err),
         ));
     }
 


### PR DESCRIPTION
Currently, the error returned by `send_transaction` cannot be traced to a specific cause, leaving the developer unable to locate where the problem occurred.
