### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gevulot
 
-Gevulot is a permissionless and programmable layer one blockchain for deploying zero-knowledge provers and verifiers as on-chain programs. It allows users to deploy and use entire proof systems on-chain, with minimal computational overhead as compared to single prover architectures. The vision of Gevulot is to make the creation and operation of zk-based systems, such as validity rollups, as easy as deploying smart contracts.
+Gevulot is a permissioned and programmable layer one blockchain for deploying zero-knowledge provers and verifiers as on-chain programs. It allows users to deploy and use entire proof systems on-chain, with minimal computational overhead as compared to single prover architectures. The vision of Gevulot is to make the creation and operation of zk-based systems, such as validity rollups, as easy as deploying smart contracts.
 
 For a more in-depth look at the network design see our [docs](https://gevulot.gitbook.io/gevulot-docs/).
 


### PR DESCRIPTION
The [documentation](https://docs.gevulot.com/gevulot-docs/devnet/overview) mentions that Gevulot is permissioned network, but the readme is permissionless. So what's it like?