### PR TITLE
Verify that the program id is present or wait for the deploy Tx

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -148,6 +148,17 @@ fn generate_key(opts: KeyOptions) -> Result<()> {
 }
 
 #[async_trait]
+impl txvalidation::ValidateStorage for storage::Database {
+    async fn get_tx(&self, hash: &Hash) -> Result<Option<Transaction<Validated>>> {
+        self.find_transaction(hash).await
+    }
+
+    async fn contains_program(&self, hash: Hash) -> Result<bool> {
+        self.find_program(hash).await.map(|res| res.is_some())
+    }
+}
+
+#[async_trait]
 impl mempool::Storage for storage::Database {
     async fn get(&self, hash: &Hash) -> Result<Option<Transaction<Validated>>> {
         self.find_transaction(hash).await

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -270,6 +270,7 @@ impl TxEvent<WaitTx> {
         ) -> impl Future<Output = eyre::Result<bool>> + 'a {
             storage.contains_program(*cache_key)
         }
+
         // Test  all Tx progam id because Run tx can have program from different deploy Tx.
         let mut new_tx: Option<Self> = Some(self);
         for program_id in run_tx_programs {

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -326,6 +326,13 @@ impl TxEvent<WaitTx> {
         }
         // Only test for the first program, because all Tx program came from the same deploy tx.
         let parent = self.tx.payload.get_parent_tx().cloned();
+        tracing::warn!(
+            "manage_parent_dep parent {:?}",
+            parent
+                .iter()
+                .map(|hash| hash.to_string())
+                .collect::<Vec<_>>()
+        );
         let new_tx = self
             .wait_if_not_cached(parent_cache, parent.as_ref(), storage, query_db_for_tx)
             .await?;

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -299,6 +299,14 @@ impl TxEvent<WaitTx> {
             })
             .unwrap_or(vec![]);
 
+        tracing::warn!(
+            "manage_program_dep {:?}",
+            new_txs
+                .iter()
+                .map(|tx| tx.tx.hash.to_string())
+                .collect::<Vec<_>>()
+        );
+
         Ok(new_txs)
     }
 
@@ -336,6 +344,14 @@ impl TxEvent<WaitTx> {
         for new_tx in &new_txs {
             parent_cache.add_cached_tx(new_tx.tx.hash);
         }
+
+        tracing::warn!(
+            "manage_parent_dep {:?}",
+            new_txs
+                .iter()
+                .map(|tx| tx.tx.hash.to_string())
+                .collect::<Vec<_>>()
+        );
 
         Ok(new_txs)
     }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -312,6 +312,14 @@ impl TxEvent<WaitTx> {
             })
             .unwrap_or(vec![]);
 
+        tracing::warn!(
+            "manage_program_dep {:?}",
+            new_txs
+                .iter()
+                .map(|tx| tx.tx.hash.to_string())
+                .collect::<Vec<_>>()
+        );
+
         Ok(new_txs)
     }
 

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -172,7 +172,7 @@ impl TxEvent<DownloadTx> {
     }
 }
 
-//Propagate Tx processing
+// Propagate Tx processing.
 impl TxEvent<PropagateTx> {
     pub async fn process_event(
         self,
@@ -203,7 +203,6 @@ impl TxEvent<PropagateTx> {
 // Do it in 2 step.
 // Manage Run Tx and put to wait depending on progam.
 // Manage Proof and Verify Tx to wait depending on Run Tx.
-
 impl TxEvent<WaitTx> {
     pub async fn process_event(
         self,
@@ -322,7 +321,7 @@ impl TxEvent<WaitTx> {
             .wait_if_not_cached(parent_cache, parent.as_ref(), storage, query_db_for_tx)
             .await?;
 
-        //remove child Tx if any from waiting list.
+        // Remove child Tx if any from waiting list.
         let new_txs = new_tx
             .map(|tx| {
                 let mut ret = parent_cache.remove_waiting_children_txs(&tx.tx.hash);

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -361,7 +361,6 @@ impl TxEvent<WaitTx> {
         for new_tx in &new_txs {
             parent_cache.add_cached_tx(new_tx.tx.hash);
         }
-
         Ok(new_txs)
     }
 }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -331,7 +331,6 @@ impl TxEvent<WaitTx> {
                 .get_tx(cache_key)
                 .and_then(|res| async move { Ok(res.is_some()) })
         }
-        // Only test for the first program, because all Tx program came from the same deploy tx.
         let parent = self.tx.payload.get_parent_tx().cloned();
         let new_tx = self
             .wait_if_not_cached(parent_cache, parent.as_ref(), storage, query_db_for_tx)

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -299,14 +299,6 @@ impl TxEvent<WaitTx> {
             })
             .unwrap_or(vec![]);
 
-        tracing::warn!(
-            "manage_program_dep {:?}",
-            new_txs
-                .iter()
-                .map(|tx| tx.tx.hash.to_string())
-                .collect::<Vec<_>>()
-        );
-
         Ok(new_txs)
     }
 
@@ -326,13 +318,6 @@ impl TxEvent<WaitTx> {
         }
         // Only test for the first program, because all Tx program came from the same deploy tx.
         let parent = self.tx.payload.get_parent_tx().cloned();
-        tracing::warn!(
-            "manage_parent_dep parent {:?}",
-            parent
-                .iter()
-                .map(|hash| hash.to_string())
-                .collect::<Vec<_>>()
-        );
         let new_tx = self
             .wait_if_not_cached(parent_cache, parent.as_ref(), storage, query_db_for_tx)
             .await?;
@@ -351,14 +336,6 @@ impl TxEvent<WaitTx> {
         for new_tx in &new_txs {
             parent_cache.add_cached_tx(new_tx.tx.hash);
         }
-
-        tracing::warn!(
-            "manage_parent_dep {:?}",
-            new_txs
-                .iter()
-                .map(|tx| tx.tx.hash.to_string())
-                .collect::<Vec<_>>()
-        );
 
         Ok(new_txs)
     }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -312,14 +312,6 @@ impl TxEvent<WaitTx> {
             })
             .unwrap_or(vec![]);
 
-        tracing::warn!(
-            "manage_program_dep {:?}",
-            new_txs
-                .iter()
-                .map(|tx| tx.tx.hash.to_string())
-                .collect::<Vec<_>>()
-        );
-
         Ok(new_txs)
     }
 
@@ -340,13 +332,6 @@ impl TxEvent<WaitTx> {
         }
         // Only test for the first program, because all Tx program came from the same deploy tx.
         let parent = self.tx.payload.get_parent_tx().cloned();
-        tracing::warn!(
-            "manage_parent_dep parent {:?}",
-            parent
-                .iter()
-                .map(|hash| hash.to_string())
-                .collect::<Vec<_>>()
-        );
         let new_tx = self
             .wait_if_not_cached(parent_cache, parent.as_ref(), storage, query_db_for_tx)
             .await?;

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -310,7 +310,7 @@ impl TxEvent<WaitTx> {
                 ret_tx.insert(0, tx);
                 ret_tx
             })
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
 
         Ok(new_txs)
     }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -362,9 +362,10 @@ impl TxEvent<NewTx> {
             tx.hash.to_string(),
             tx.payload
         );
+        let tx_hash = tx.hash;
         newtx_receiver
             .send_new_tx(tx)
-            .map_err(|err| EventProcessError::SaveTxError(format!("{err}")))
+            .map_err(|err| EventProcessError::SaveTxError(format!("Tx:{} {err}", tx_hash)))
             .await
     }
 }

--- a/crates/node/src/txvalidation/event.rs
+++ b/crates/node/src/txvalidation/event.rs
@@ -340,6 +340,13 @@ impl TxEvent<WaitTx> {
         }
         // Only test for the first program, because all Tx program came from the same deploy tx.
         let parent = self.tx.payload.get_parent_tx().cloned();
+        tracing::warn!(
+            "manage_parent_dep parent {:?}",
+            parent
+                .iter()
+                .map(|hash| hash.to_string())
+                .collect::<Vec<_>>()
+        );
         let new_tx = self
             .wait_if_not_cached(parent_cache, parent.as_ref(), storage, query_db_for_tx)
             .await?;

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -1,10 +1,10 @@
-use crate::mempool::Storage;
 use crate::txvalidation::event::TxCache;
 use crate::txvalidation::event::{ReceivedTx, TxEvent};
 use crate::types::{
     transaction::{Created, Received, Validated},
-    Transaction,
+    Hash, Program, Transaction,
 };
+use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use futures_util::Stream;
 use futures_util::TryFutureExt;
@@ -33,6 +33,12 @@ mod event;
 #[async_trait::async_trait]
 pub trait ValidatedTxReceiver: Send + Sync {
     async fn send_new_tx(&mut self, tx: Transaction<Validated>) -> eyre::Result<()>;
+}
+
+#[async_trait]
+pub trait ValidateStorage: Send + Sync {
+    async fn get_tx(&self, hash: &Hash) -> eyre::Result<Option<Transaction<Validated>>>;
+    async fn contains_program(&self, hash: Hash) -> eyre::Result<bool>;
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -139,7 +145,7 @@ pub async fn spawn_event_loop(
     mut rcv_tx_event_rx: UnboundedReceiver<(Transaction<Received>, Option<CallbackSender>)>,
     // Endpoint where validated transactions are sent to. Usually configured with Mempool.
     new_tx_receiver: Arc<RwLock<dyn ValidatedTxReceiver + 'static>>,
-    storage: Arc<impl Storage + 'static>,
+    storage: Arc<impl ValidateStorage + 'static>,
 ) -> eyre::Result<(
     JoinHandle<()>,
     // Output stream used to propagate transactions.
@@ -155,7 +161,8 @@ pub async fn spawn_event_loop(
     let p2p_stream = UnboundedReceiverStream::new(p2p_recv);
     let jh = tokio::spawn({
         let local_directory_path = local_directory_path.clone();
-        let mut wait_tx_cache = TxCache::new();
+        let mut program_wait_tx_cache = TxCache::<Program>::new();
+        let mut parent_wait_tx_cache = TxCache::<Transaction<Validated>>::new();
         let mut validated_txs_futures = FuturesUnordered::new();
         let mut validation_okresult_futures = FuturesUnordered::new();
         let mut validation_errresult_futures = FuturesUnordered::new();
@@ -202,7 +209,7 @@ pub async fn spawn_event_loop(
                     Some(Ok((wait_tx_res, callback))) = validated_txs_futures.next() =>  {
                         match wait_tx_res {
                             Ok(wait_tx) => {
-                               match wait_tx.process_event(&mut wait_tx_cache, storage.as_ref()).await {
+                               match wait_tx.process_event(&mut program_wait_tx_cache, &mut parent_wait_tx_cache, storage.as_ref()).await {
                                     Ok(new_tx_list) => {
                                         //
                                         let jh  = tokio::spawn({

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -209,11 +209,11 @@ pub async fn spawn_event_loop(
                             Ok(wait_tx) => {
                                match wait_tx.process_event(&mut program_wait_tx_cache, &mut parent_wait_tx_cache, storage.as_ref()).await {
                                     Ok(new_tx_list) => {
-                                        // Process new Tx synchronized with the dependent Tx validation
-                                        // To avoid when there's a lot of Txs free by one Tx that a next Tx that
-                                        // depend on the free is saved before the free one.
+                                        // Process new Tx synchronized with the Tx validation
+                                        // to avoid when there's a lot of waiting Txs free by one Tx that a next Tx that
+                                        // depend on the free one is saved before.
                                         // Can lock the loop during the save.
-                                        // The unbounded channel will buffer the wait.
+                                        // The unbounded channel will buffer the Tx waiting.
                                         let mut res = Ok(());
                                         for new_tx in new_tx_list {
                                            if let Err(err) =  new_tx.process_event(&mut *(new_tx_receiver.write().await)).await {

--- a/crates/node/src/txvalidation/mod.rs
+++ b/crates/node/src/txvalidation/mod.rs
@@ -209,9 +209,9 @@ pub async fn spawn_event_loop(
                             Ok(wait_tx) => {
                                match wait_tx.process_event(&mut program_wait_tx_cache, &mut parent_wait_tx_cache, storage.as_ref()).await {
                                     Ok(new_tx_list) => {
-                                        // Process new Tx synchronized with the Tx validation
-                                        // to avoid when there's a lot of waiting Txs free by one Tx that a next Tx that
-                                        // depend on the free one is saved before.
+                                        // Process new Tx in the main loop
+                                        // to avoid when there's a lot of waiting Txs free by one Tx,
+                                        // an arriving Tx that depend on a just free one is saved before and generate a db constrain error.
                                         // Can lock the loop during the save.
                                         // The unbounded channel will buffer the Tx waiting.
                                         let mut res = Ok(());

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -219,6 +219,13 @@ impl Payload {
         }
     }
 
+    pub fn is_run_payload(&self) -> bool {
+        match self {
+            Payload::Run { .. } => true,
+            _ => false,
+        }
+    }
+
     pub fn serialize_into(&self, buf: &mut Vec<u8>) {
         match self {
             Payload::Empty => {}

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -220,10 +220,7 @@ impl Payload {
     }
 
     pub fn is_run_payload(&self) -> bool {
-        match self {
-            Payload::Run { .. } => true,
-            _ => false,
-        }
+        matches!(self, Payload::Run { .. })
     }
 
     pub fn serialize_into(&self, buf: &mut Vec<u8>) {

--- a/crates/node/src/types/transaction.rs
+++ b/crates/node/src/types/transaction.rs
@@ -202,6 +202,23 @@ impl Payload {
             _ => None,
         }
     }
+
+    pub fn get_deploy_programs(&self) -> Vec<Hash> {
+        match self {
+            Payload::Deploy {
+                prover, verifier, ..
+            } => vec![prover.hash, verifier.hash],
+            _ => vec![],
+        }
+    }
+
+    pub fn get_run_programs_dep(&self) -> Vec<Hash> {
+        match self {
+            Payload::Run { workflow } => workflow.steps.iter().map(|s| s.program).collect(),
+            _ => vec![],
+        }
+    }
+
     pub fn serialize_into(&self, buf: &mut Vec<u8>) {
         match self {
             Payload::Empty => {}

--- a/crates/tests/e2e-tests/src/main.rs
+++ b/crates/tests/e2e-tests/src/main.rs
@@ -56,14 +56,13 @@ async fn main() -> Result<()> {
     .await
     .expect("deploy");
 
-    for nonce in 1..20 {
+    for nonce in 1..2 {
         send_proving_task(&client, &key, nonce, &prover_hash, &verifier_hash)
             .await
             .expect("send proving task");
-        sleep(Duration::from_millis(300)).await;
     }
 
-    //sleep(Duration::from_secs(360)).await;
+    sleep(Duration::from_secs(360)).await;
 
     Ok(())
 }

--- a/crates/tests/e2e-tests/src/main.rs
+++ b/crates/tests/e2e-tests/src/main.rs
@@ -56,13 +56,14 @@ async fn main() -> Result<()> {
     .await
     .expect("deploy");
 
-    for nonce in 1..2 {
+    for nonce in 1..20 {
         send_proving_task(&client, &key, nonce, &prover_hash, &verifier_hash)
             .await
             .expect("send proving task");
+        sleep(Duration::from_millis(300)).await;
     }
 
-    sleep(Duration::from_secs(360)).await;
+    //sleep(Duration::from_secs(360)).await;
 
     Ok(())
 }


### PR DESCRIPTION
The same way Tx wait for their parent, this PR add the wait for the deploy Tx associated to the Tx program id if not present.
Only Run tx are tested for program id because proof and verify Tx depend on the Run. If the Run wait for the program id proof and verify Tx will wait for the run.

I synchronize the wait verification and the Tx save because some time Wait Tx verification can return several Txs and if it contains a Run Tx for example, the dependent proof that arrive after can be saved before because the batch of Tx take more time to save than one Tx verification and save.
I add the case in my test.

I declare a specific storage trait for the verification.

With the `wait_if_not_cached` function I try to share the same logic between the program dep and the parent dep verification but not sure, it adds because of the complexity to make it with async future.

I test it with 3 nodes connected.
