### PR TITLE
Add support for P2P protocol v1 (when orig. is v0)

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -259,6 +259,7 @@ async fn run(config: Arc<Config>) -> Result<()> {
     .await?;
 
     let public_node_key = PublicKey::from_secret_key(&node_key);
+    let node_resources = scheduler::get_configured_resources(&config);
     let p2p = Arc::new(
         networking::P2P::new(
             "gevulot-p2p-network",
@@ -270,6 +271,7 @@ async fn run(config: Arc<Config>) -> Result<()> {
             http_peer_list,
             txvalidation::TxEventSender::<txvalidation::P2pSender>::build(tx_sender.clone()),
             p2p_stream,
+            node_resources,
         )
         .await,
     );
@@ -345,6 +347,7 @@ async fn p2p_beacon(config: P2PBeaconConfig) -> Result<()> {
             http_peer_list,
             txvalidation::TxEventSender::<txvalidation::P2pSender>::build(tx),
             p2p_stream,
+            (0, 0, 0), // P2P beacon node's resources aren't really important.
         )
         .await,
     );

--- a/crates/node/src/metrics/mod.rs
+++ b/crates/node/src/metrics/mod.rs
@@ -113,3 +113,8 @@ pub(crate) async fn serve_metrics(bind_addr: SocketAddr) -> Result<()> {
 
     Ok(())
 }
+
+pub(crate) fn export_metrics() -> Vec<u8> {
+    // TODO: Implement :)
+    Vec::new()
+}

--- a/crates/node/src/networking/p2p/pea2pea.rs
+++ b/crates/node/src/networking/p2p/pea2pea.rs
@@ -102,7 +102,7 @@ impl P2P {
             http_port,
             nat_listen_addr,
             tx_sender,
-            protocol_version: 0,
+            protocol_version: 1,
             node_resources,
         };
 

--- a/crates/node/src/networking/p2p/protocol/internal.rs
+++ b/crates/node/src/networking/p2p/protocol/internal.rs
@@ -1,45 +1,43 @@
 use std::{collections::BTreeSet, net::SocketAddr};
 
-use gevulot_node::types;
+use gevulot_node::types::{self, transaction::Validated};
 use libsecp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) enum Handshake {
-    V1(HandshakeV1),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct HandshakeV1 {
+pub(crate) struct Handshake {
     pub my_p2p_listen_addr: SocketAddr,
     pub peers: BTreeSet<SocketAddr>,
     pub http_port: Option<u16>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) enum Message {
-    V0(MessageV0),
-}
-
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) enum MessageV0 {
-    Transaction(types::Transaction<types::transaction::Validated>),
+pub(crate) enum Message {
+    Transaction(types::Transaction<Validated>),
     DiagnosticsRequest(DiagnosticsRequestKind),
-    DiagnosticsResponse(PublicKey, DiagnosticsResponseV0),
+    DiagnosticsResponse(PublicKey, DiagnosticsResponse),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) enum DiagnosticsRequestKind {
     Version,
+    Resources,
+    Metrics,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) enum DiagnosticsResponseV0 {
+pub(crate) enum DiagnosticsResponse {
     Version {
         major: u16,
         minor: u16,
         patch: u16,
         build: String,
     },
+    Resources {
+        cpus: u64,
+        mem: u64,
+        gpus: u64,
+    },
+    Metrics(Vec<u8>),
 }

--- a/crates/node/src/networking/p2p/protocol/mod.rs
+++ b/crates/node/src/networking/p2p/protocol/mod.rs
@@ -1,0 +1,186 @@
+use eyre::{eyre, Result};
+
+pub mod internal;
+pub mod v0;
+pub mod v1;
+
+pub fn serialize_handshake(msg: internal::Handshake) -> Result<Vec<u8>> {
+    let msg = v0::Handshake::from(msg);
+    bincode::serialize(&msg).map_err(|e| e.into())
+}
+
+pub fn new_serialize_handshake(protocol_version: u64, msg: internal::Handshake) -> Result<Vec<u8>> {
+    match protocol_version {
+        0 => bincode::serialize(&v0::Handshake::from(msg)),
+        1 => bincode::serialize(&v1::Handshake::from(msg)),
+        ver => return Err(eyre!("unknown protocol version: {ver}")),
+    }
+    .map(|mut bs| {
+        let mut data = Vec::with_capacity(bs.len() + 8);
+        data.append(&mut protocol_version.to_be_bytes().to_vec());
+        data.append(&mut bs);
+        data
+    })
+    .map_err(|e| e.into())
+}
+
+pub fn deserialize_handshake(bs: &[u8]) -> Result<internal::Handshake> {
+    let res = v0::Handshake::parse(bs);
+    if res.is_ok() {
+        return res;
+    }
+
+    if bs.len() < 9 {
+        return Err(eyre!("invalid handshake message: too short"));
+    }
+
+    match u64::from_be_bytes(bs[0..8].try_into().expect("convert slice to array")) {
+        0 => v0::Handshake::parse(&bs[8..]),
+        1 => v1::Handshake::parse(&bs[8..]),
+        ver => Err(eyre!("unknown protocol version: {ver}")),
+    }
+}
+
+pub fn serialize_msg(msg: internal::Message) -> Result<Vec<u8>> {
+    let msg = v0::Message::from(msg);
+    bincode::serialize(&msg).map_err(|e| e.into())
+}
+
+pub fn new_serialize_msg(protocol_version: u64, msg: internal::Message) -> Result<Vec<u8>> {
+    match protocol_version {
+        0 => bincode::serialize(&v0::Message::from(msg)),
+        1 => bincode::serialize(&v1::Message::from(msg)),
+        ver => return Err(eyre!("unknown protocol version: {ver}")),
+    }
+    .map(|mut bs| {
+        let mut data = Vec::with_capacity(bs.len() + 8);
+        data.append(&mut protocol_version.to_be_bytes().to_vec());
+        data.append(&mut bs);
+        data
+    })
+    .map_err(|e| e.into())
+}
+
+pub fn deserialize_msg(bs: &[u8]) -> Result<internal::Message> {
+    let res = v0::Message::parse(bs);
+    if res.is_ok() {
+        return res;
+    }
+
+    if bs.len() < 9 {
+        return Err(eyre!("invalid protocol message: too short"));
+    }
+
+    match u64::from_be_bytes(bs[0..8].try_into().expect("convert slice to array")) {
+        0 => v0::Message::parse(&bs[8..]),
+        1 => v1::Message::parse(&bs[8..]),
+        ver => Err(eyre!("unknown protocol version: {ver}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use gevulot_node::types::{
+        transaction::{Created, Payload, Validated},
+        Transaction,
+    };
+    use libsecp256k1::SecretKey;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_tx_serialization_between_v0_and_v1() {
+        let orig_tx = new_tx();
+        let bs =
+            serialize_msg(internal::Message::Transaction(orig_tx.clone())).expect("serialize tx");
+
+        let msg: v1::Message = bincode::deserialize(bs.as_ref()).expect("deserialize v1 message");
+        if let v1::Message::V1(v1::MessageV1::Transaction(tx)) = msg {
+            println!("deserialized tx: {:?}", tx);
+            assert_eq!(orig_tx, tx);
+        } else {
+            panic!("test failed: Couldn't deserialize transaction correctly.");
+        }
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let orig_tx = new_tx();
+        let bs =
+            serialize_msg(internal::Message::Transaction(orig_tx.clone())).expect("serialize tx");
+        let msg = deserialize_msg(bs.as_ref()).expect("deserialize_msg");
+
+        if let internal::Message::Transaction(tx) = msg {
+            println!("deserialized tx: {:?}", tx);
+            assert_eq!(orig_tx, tx);
+        } else {
+            panic!("test failed: Couldn't deserialize transaction correctly.");
+        }
+    }
+
+    #[test]
+    fn test_v0_serialize_to_deserialize() {
+        let orig_tx = new_tx();
+        let msg = v0::Message::V0(v0::MessageV0::Transaction(orig_tx.clone()));
+        let bs = bincode::serialize(&msg).expect("serialize message");
+
+        let deserialized_msg = deserialize_msg(bs.as_ref()).expect("deserialize v0");
+
+        if let internal::Message::Transaction(tx) = deserialized_msg {
+            println!("deserialized tx: {:?}", &tx);
+            assert_eq!(orig_tx, tx);
+        } else {
+            panic!("test failed: Couldn't deserialize transaction correctly.");
+        }
+    }
+
+    #[test]
+    fn test_new_serialize_v0_to_deserialize() {
+        let orig_tx = new_tx();
+        let msg = internal::Message::Transaction(orig_tx.clone());
+        let bs = new_serialize_msg(0, msg).expect("serialize message");
+
+        let deserialized_msg = deserialize_msg(bs.as_ref()).expect("deserialize v0");
+
+        if let internal::Message::Transaction(tx) = deserialized_msg {
+            println!("deserialized tx: {:?}", &tx);
+            assert_eq!(orig_tx, tx);
+        } else {
+            panic!("test failed: Couldn't deserialize transaction correctly.");
+        }
+    }
+
+    #[test]
+    fn test_new_serialize_v1_to_deserialize() {
+        let orig_tx = new_tx();
+        let msg = internal::Message::Transaction(orig_tx.clone());
+        let bs = new_serialize_msg(1, msg).expect("serialize message");
+
+        let deserialized_msg = deserialize_msg(bs.as_ref()).expect("deserialize v0");
+
+        if let internal::Message::Transaction(tx) = deserialized_msg {
+            println!("deserialized tx: {:?}", &tx);
+            assert_eq!(orig_tx, tx);
+        } else {
+            panic!("test failed: Couldn't deserialize transaction correctly.");
+        }
+    }
+
+    fn new_tx() -> Transaction<Validated> {
+        let rng = &mut StdRng::from_entropy();
+
+        let tx = Transaction::<Created>::new(Payload::Empty, &SecretKey::random(rng));
+
+        Transaction {
+            author: tx.author,
+            hash: tx.hash,
+            payload: tx.payload,
+            nonce: tx.nonce,
+            signature: tx.signature,
+            propagated: tx.executed,
+            executed: tx.executed,
+            state: Validated,
+        }
+    }
+}

--- a/crates/node/src/networking/p2p/protocol/v0.rs
+++ b/crates/node/src/networking/p2p/protocol/v0.rs
@@ -1,0 +1,160 @@
+use eyre::Result;
+use std::{collections::BTreeSet, net::SocketAddr};
+
+use gevulot_node::types;
+use libsecp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+
+use super::internal;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum Handshake {
+    V1(HandshakeV1),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct HandshakeV1 {
+    pub my_p2p_listen_addr: SocketAddr,
+    pub peers: BTreeSet<SocketAddr>,
+    pub http_port: Option<u16>,
+}
+
+impl From<internal::Handshake> for Handshake {
+    fn from(value: internal::Handshake) -> Self {
+        let internal::Handshake {
+            my_p2p_listen_addr,
+            peers,
+            http_port,
+        } = value;
+        Handshake::V1(HandshakeV1 {
+            my_p2p_listen_addr,
+            peers,
+            http_port,
+        })
+    }
+}
+
+impl Handshake {
+    pub fn parse(bs: &[u8]) -> Result<internal::Handshake> {
+        match bincode::deserialize(bs) {
+            Ok(Handshake::V1(HandshakeV1 {
+                my_p2p_listen_addr,
+                peers,
+                http_port,
+            })) => Ok(internal::Handshake {
+                my_p2p_listen_addr,
+                peers,
+                http_port,
+            }),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum Message {
+    V0(MessageV0),
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum MessageV0 {
+    Transaction(types::Transaction<types::transaction::Validated>),
+    DiagnosticsRequest(DiagnosticsRequestKind),
+    DiagnosticsResponse(PublicKey, DiagnosticsResponseV0),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum DiagnosticsRequestKind {
+    Version,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum DiagnosticsResponseV0 {
+    Version {
+        major: u16,
+        minor: u16,
+        patch: u16,
+        build: String,
+    },
+}
+
+impl From<internal::Message> for Message {
+    fn from(value: internal::Message) -> Self {
+        match value {
+            internal::Message::Transaction(tx) => Message::V0(MessageV0::Transaction(tx)),
+            internal::Message::DiagnosticsRequest(kind) => Message::V0(
+                MessageV0::DiagnosticsRequest(DiagnosticsRequestKind::Version),
+            ),
+            internal::Message::DiagnosticsResponse(pubkey, response) => match response {
+                internal::DiagnosticsResponse::Version {
+                    major,
+                    minor,
+                    patch,
+                    build,
+                } => Message::V0(MessageV0::DiagnosticsResponse(
+                    pubkey,
+                    DiagnosticsResponseV0::Version {
+                        major,
+                        minor,
+                        patch,
+                        build,
+                    },
+                )),
+                internal::DiagnosticsResponse::Resources { cpus, mem, gpus } => {
+                    Message::V0(MessageV0::DiagnosticsResponse(
+                        pubkey,
+                        DiagnosticsResponseV0::Version {
+                            major: 0,
+                            minor: 0,
+                            patch: 0,
+                            build: String::new(),
+                        },
+                    ))
+                }
+                internal::DiagnosticsResponse::Metrics(data) => {
+                    Message::V0(MessageV0::DiagnosticsResponse(
+                        pubkey,
+                        DiagnosticsResponseV0::Version {
+                            major: 0,
+                            minor: 0,
+                            patch: 0,
+                            build: String::new(),
+                        },
+                    ))
+                }
+            },
+        }
+    }
+}
+
+impl Message {
+    pub fn parse(bs: &[u8]) -> Result<internal::Message> {
+        match bincode::deserialize(bs) {
+            Ok(Message::V0(msg)) => match msg {
+                MessageV0::Transaction(tx) => Ok(internal::Message::Transaction(tx)),
+                MessageV0::DiagnosticsRequest(_) => Ok(internal::Message::DiagnosticsRequest(
+                    internal::DiagnosticsRequestKind::Version,
+                )),
+                MessageV0::DiagnosticsResponse(
+                    pubkey,
+                    DiagnosticsResponseV0::Version {
+                        major,
+                        minor,
+                        patch,
+                        build,
+                    },
+                ) => Ok(internal::Message::DiagnosticsResponse(
+                    pubkey,
+                    internal::DiagnosticsResponse::Version {
+                        major,
+                        minor,
+                        patch,
+                        build,
+                    },
+                )),
+            },
+            Err(err) => Err(err.into()),
+        }
+    }
+}

--- a/crates/node/src/networking/p2p/protocol/v1.rs
+++ b/crates/node/src/networking/p2p/protocol/v1.rs
@@ -1,0 +1,183 @@
+use eyre::Result;
+use std::{collections::BTreeSet, net::SocketAddr};
+
+use gevulot_node::types;
+use libsecp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+
+use super::internal;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum Handshake {
+    V1(HandshakeV1),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct HandshakeV1 {
+    pub my_p2p_listen_addr: SocketAddr,
+    pub peers: BTreeSet<SocketAddr>,
+    pub http_port: Option<u16>,
+}
+
+impl From<internal::Handshake> for Handshake {
+    fn from(value: internal::Handshake) -> Self {
+        let internal::Handshake {
+            my_p2p_listen_addr,
+            peers,
+            http_port,
+        } = value;
+        Handshake::V1(HandshakeV1 {
+            my_p2p_listen_addr,
+            peers,
+            http_port,
+        })
+    }
+}
+
+impl Handshake {
+    pub fn parse(bs: &[u8]) -> Result<internal::Handshake> {
+        match bincode::deserialize(bs) {
+            Ok(Handshake::V1(HandshakeV1 {
+                my_p2p_listen_addr,
+                peers,
+                http_port,
+            })) => Ok(internal::Handshake {
+                my_p2p_listen_addr,
+                peers,
+                http_port,
+            }),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum Message {
+    V1(MessageV1),
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum MessageV1 {
+    Transaction(types::Transaction<types::transaction::Validated>),
+    DiagnosticsRequest(DiagnosticsRequestKind),
+    DiagnosticsResponse(PublicKey, DiagnosticsResponseV1),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum DiagnosticsRequestKind {
+    Version,
+    Resources,
+    Metrics,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum DiagnosticsResponseV1 {
+    Version {
+        major: u16,
+        minor: u16,
+        patch: u16,
+        build: String,
+    },
+    Resources {
+        cpus: u64,
+        mem: u64,
+        gpus: u64,
+    },
+    Metrics(Vec<u8>),
+}
+
+impl From<internal::Message> for Message {
+    fn from(value: internal::Message) -> Self {
+        match value {
+            internal::Message::Transaction(tx) => Message::V1(MessageV1::Transaction(tx)),
+            internal::Message::DiagnosticsRequest(kind) => match kind {
+                internal::DiagnosticsRequestKind::Version => Message::V1(
+                    MessageV1::DiagnosticsRequest(DiagnosticsRequestKind::Version),
+                ),
+                internal::DiagnosticsRequestKind::Resources => Message::V1(
+                    MessageV1::DiagnosticsRequest(DiagnosticsRequestKind::Resources),
+                ),
+                internal::DiagnosticsRequestKind::Metrics => Message::V1(
+                    MessageV1::DiagnosticsRequest(DiagnosticsRequestKind::Metrics),
+                ),
+            },
+            internal::Message::DiagnosticsResponse(pubkey, response) => match response {
+                internal::DiagnosticsResponse::Version {
+                    major,
+                    minor,
+                    patch,
+                    build,
+                } => Message::V1(MessageV1::DiagnosticsResponse(
+                    pubkey,
+                    DiagnosticsResponseV1::Version {
+                        major,
+                        minor,
+                        patch,
+                        build,
+                    },
+                )),
+                internal::DiagnosticsResponse::Resources { cpus, mem, gpus } => {
+                    Message::V1(MessageV1::DiagnosticsResponse(
+                        pubkey,
+                        DiagnosticsResponseV1::Resources { cpus, mem, gpus },
+                    ))
+                }
+                internal::DiagnosticsResponse::Metrics(data) => Message::V1(
+                    MessageV1::DiagnosticsResponse(pubkey, DiagnosticsResponseV1::Metrics(data)),
+                ),
+            },
+        }
+    }
+}
+
+impl Message {
+    pub fn parse(bs: &[u8]) -> Result<internal::Message> {
+        match bincode::deserialize(bs) {
+            Ok(Message::V1(msg)) => match msg {
+                MessageV1::Transaction(tx) => Ok(internal::Message::Transaction(tx)),
+                MessageV1::DiagnosticsRequest(kind) => match kind {
+                    DiagnosticsRequestKind::Version => Ok(internal::Message::DiagnosticsRequest(
+                        internal::DiagnosticsRequestKind::Version,
+                    )),
+                    DiagnosticsRequestKind::Resources => Ok(internal::Message::DiagnosticsRequest(
+                        internal::DiagnosticsRequestKind::Resources,
+                    )),
+                    DiagnosticsRequestKind::Metrics => Ok(internal::Message::DiagnosticsRequest(
+                        internal::DiagnosticsRequestKind::Metrics,
+                    )),
+                },
+
+                MessageV1::DiagnosticsResponse(pubkey, kind) => match kind {
+                    DiagnosticsResponseV1::Version {
+                        major,
+                        minor,
+                        patch,
+                        build,
+                    } => Ok(internal::Message::DiagnosticsResponse(
+                        pubkey,
+                        internal::DiagnosticsResponse::Version {
+                            major,
+                            minor,
+                            patch,
+                            build,
+                        },
+                    )),
+                    DiagnosticsResponseV1::Resources { cpus, mem, gpus } => {
+                        Ok(internal::Message::DiagnosticsResponse(
+                            pubkey,
+                            internal::DiagnosticsResponse::Resources { cpus, mem, gpus },
+                        ))
+                    }
+                    DiagnosticsResponseV1::Metrics(data) => {
+                        Ok(internal::Message::DiagnosticsResponse(
+                            pubkey,
+                            internal::DiagnosticsResponse::Metrics(data),
+                        ))
+                    }
+                },
+            },
+            Err(err) => Err(err.into()),
+        }
+    }
+}


### PR DESCRIPTION
This change makes next step in P2P protocol versioning support. While at it, this also takes the first step to add metrics into v1 protocol.

The prometheus metrics export is not part of this change yet, though.

The protocol versioning change here is built to be backwards compatible. Message versions default to v0, but have support for optional v1 compatibility as well. This change does not yet have support for protocol version negotiation between nodes, though it might be that this won't be even necessary, if nodes upgrade fast enough.