### PR TITLE
Scheduler remove lock contention

### DIFF
--- a/crates/node/src/networking/p2p/pea2pea.rs
+++ b/crates/node/src/networking/p2p/pea2pea.rs
@@ -136,7 +136,7 @@ impl P2P {
 
     async fn forward_tx(&self, tx: Transaction<Created>) {
         tracing::debug!("submitting received tx to tx_handler");
-        if let Err(err) = self.tx_sender.send_tx(tx) {
+        if let Err(err) = self.tx_sender.send_tx(tx).await {
             tracing::error!("P2P error during received Tx sending:{err}");
         }
     }

--- a/crates/node/src/scheduler/mod.rs
+++ b/crates/node/src/scheduler/mod.rs
@@ -1,6 +1,11 @@
+use crate::types::transaction::Created;
+use crate::vmm::VMHandle;
+use gevulot_node::types::transaction::Validated;
+use tokio_stream::StreamExt;
 mod program_manager;
-mod resource_manager;
+pub mod resource_manager;
 
+use self::program_manager::ProgramHandle;
 use crate::cli::Config;
 use crate::storage::Database;
 use crate::txvalidation;
@@ -8,18 +13,17 @@ use crate::txvalidation::CallbackSender;
 use crate::txvalidation::TxEventSender;
 use crate::txvalidation::TxResultSender;
 use crate::types::file::{move_vmfile, Output, TaskVmFile, TxFile, VmOutput};
-use crate::types::TaskState;
 use crate::vmm::qemu::Qemu;
 use crate::vmm::vm_server::grpc;
-use crate::vmm::vm_server::TaskManager;
+use crate::vmm::vm_server::ShareVMRunningTaskMap;
 use crate::vmm::vm_server::VMServer;
 use crate::workflow::{WorkflowEngine, WorkflowError};
 use crate::{
     mempool::Mempool,
     types::{Hash, Task},
 };
-use async_trait::async_trait;
 use eyre::Result;
+use futures::stream::FuturesUnordered;
 use gevulot_node::types::transaction::Payload;
 use gevulot_node::types::transaction::Received;
 use gevulot_node::types::{TaskKind, Transaction};
@@ -37,15 +41,11 @@ use std::{
 use systemstat::ByteSize;
 use systemstat::Platform;
 use systemstat::System;
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::{
-    sync::{Mutex, RwLock},
-    time::sleep,
-};
+use thiserror::Error;
+use tokio::select;
+use tokio::sync::mpsc::Sender;
+use tokio::{sync::RwLock, time::sleep};
 use tonic::transport::Server;
-
-use self::program_manager::{ProgramError, ProgramHandle};
-use self::resource_manager::ResourceError;
 
 // If VM doesn't have running task within `MAX_VM_IDLE_RUN_TIME`, it will be terminated.
 const MAX_VM_IDLE_RUN_TIME: Duration = Duration::from_secs(10);
@@ -82,30 +82,14 @@ impl SchedulerState {
     }
 }
 
-// TODO: I believe `Scheduler` should be rather named `Node` at some point. It
-// has started to become as a kind of central place for node logic
-// coordination.
-//
-// It could use some re-structuring in order to not be so convoluted, but
-// otherwise it seems to be okayish.
-pub struct Scheduler {
-    database: Arc<Database>,
-    workflow_engine: Arc<WorkflowEngine>,
-    node_key: SecretKey,
-
-    state: Arc<Mutex<SchedulerState>>,
-    data_directory: PathBuf,
-    http_download_host: String,
-    tx_sender: TxEventSender<TxResultSender>,
-}
-
 pub async fn start_scheduler(
     config: Arc<Config>,
     storage: Arc<Database>,
     mempool: Arc<RwLock<Mempool>>,
     node_key: SecretKey,
-    tx_sender: UnboundedSender<(Transaction<Received>, Option<CallbackSender>)>,
-) -> Arc<Scheduler> {
+    tx_sender: Sender<(Transaction<Received>, Option<CallbackSender>)>,
+    exec_receiver: tokio::sync::mpsc::Receiver<Transaction<Validated>>,
+) {
     let sys = System::new();
     let num_gpus = if config.gpu_devices.is_some() { 1 } else { 0 };
     let num_cpus = match config.num_cpus {
@@ -129,19 +113,11 @@ pub async fn start_scheduler(
         num_gpus
     );
 
-    let resource_manager = Arc::new(std::sync::Mutex::new(ResourceManager::new(
-        available_mem,
-        num_cpus,
-        num_gpus,
-    )));
+    let resource_manager = ResourceManager::new(available_mem, num_cpus, num_gpus);
 
     // TODO(tuommaki): Handle provider from config.
     let qemu_provider = Qemu::new(config.clone());
     let vsock_stream = qemu_provider.vm_server_listener().expect("vsock bind");
-
-    let provider = Arc::new(Mutex::new(qemu_provider));
-    let program_manager =
-        ProgramManager::new(storage.clone(), provider.clone(), resource_manager.clone());
 
     let workflow_engine = Arc::new(WorkflowEngine::new(storage.clone()));
     let download_url_prefix = format!(
@@ -153,15 +129,24 @@ pub async fn start_scheduler(
     let scheduler = Arc::new(Scheduler::new(
         mempool.clone(),
         storage.clone(),
-        program_manager,
         workflow_engine,
         node_key,
         config.data_directory.clone(),
+        config.log_directory.clone(),
         download_url_prefix,
         txvalidation::TxEventSender::<txvalidation::TxResultSender>::build(tx_sender.clone()),
     ));
 
-    let vm_server = VMServer::new(scheduler.clone(), provider, config.data_directory.clone());
+    //Define submit result channel
+    let (submit_result_tx, submit_result_rx) = tokio::sync::mpsc::channel(1000);
+
+    //define task mutex between VM exe and scheduler
+    let share_running_task = ShareVMRunningTaskMap::new();
+    let vm_server = VMServer::new(
+        share_running_task.clone(),
+        config.data_directory.clone(),
+        submit_result_tx,
+    );
 
     // Start gRPC VSOCK server.
     tokio::spawn(async move {
@@ -170,7 +155,56 @@ pub async fn start_scheduler(
             .serve_with_incoming(vsock_stream)
             .await
     });
-    scheduler
+
+    // Run Scheduler in its own task.
+    tokio::spawn(async move {
+        scheduler
+            .run2(
+                qemu_provider,
+                resource_manager,
+                share_running_task,
+                mempool,
+                submit_result_rx,
+                exec_receiver,
+            )
+            .await
+    });
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Error, Debug)]
+pub enum ExecuteTaskError {
+    #[error("Task:{0} Execution: Input file copy fail: {1}")]
+    InputFileCopyFailError(Hash, u32, String),
+    #[error("Task Execution: Allocation fail for: {0}")]
+    NotEnoughResources(String),
+    #[error("Task Execution: Program:{0} not found")]
+    ProgramNotFound(Hash),
+    #[error("Task Execution: Error from the database:{0}")]
+    DatabaseError(String),
+    #[error("Task Execution: Start of the VM fail:{0}")]
+    VMStartExecutionFail(String),
+    #[error("Task Execution: Start of the VM fail:{0}")]
+    VMExecutionError(Hash, u32, String),
+    #[error("Task Execution: error during submit result:{0}")]
+    SubmitResultError(String),
+}
+
+// TODO: I believe `Scheduler` should be rather named `Node` at some point. It
+// has started to become as a kind of central place for node logic
+// coordination.
+//
+// It could use some re-structuring in order to not be so convoluted, but
+// otherwise it seems to be okayish.
+pub struct Scheduler {
+    database: Arc<Database>,
+    workflow_engine: Arc<WorkflowEngine>,
+    node_key: SecretKey,
+    //    state: Arc<Mutex<SchedulerState>>,
+    data_directory: PathBuf,
+    log_directory: PathBuf,
+    http_download_host: String,
+    tx_sender: TxEventSender<TxResultSender>,
 }
 
 impl Scheduler {
@@ -178,10 +212,10 @@ impl Scheduler {
     pub fn new(
         mempool: Arc<RwLock<Mempool>>,
         database: Arc<Database>,
-        program_manager: ProgramManager,
         workflow_engine: Arc<WorkflowEngine>,
         node_key: SecretKey,
         data_directory: PathBuf,
+        log_directory: PathBuf,
         http_download_host: String,
         tx_sender: TxEventSender<TxResultSender>,
     ) -> Self {
@@ -190,448 +224,483 @@ impl Scheduler {
             workflow_engine,
             node_key,
 
-            state: Arc::new(Mutex::new(SchedulerState::new(mempool, program_manager))),
+            //            state: Arc::new(Mutex::new(SchedulerState::new(mempool, program_manager))),
             data_directory,
+            log_directory,
             http_download_host,
             tx_sender,
         }
     }
 
-    pub async fn run(&self) -> Result<()> {
-        'SCHEDULING_LOOP: loop {
-            // Reap terminated tasks & VMs.
-            self.reap_zombies().await;
-
-            // Before scheduling new workload, try to start pending programs first.
-            {
-                let mut state = self.state.lock().await;
-
-                // Make a local copy of pending programs so that when some
-                // programs fail to start and are rescheduled, they won't
-                // cause an infinite loop here.
-                let mut current_pending_programs = state.pending_programs.clone();
-                while let Some((tx_hash, program_id)) = current_pending_programs.pop_front() {
-                    // Pop from the actual pending program queue as well.
-                    state.pending_programs.pop_front();
-
-                    match state
-                        .program_manager
-                        .start_program(tx_hash, program_id, None)
-                        .await
-                    {
-                        Ok(p) => {
-                            state.running_vms.insert(tx_hash, p);
-                        }
-                        Err(e) if e.is::<ResourceError>() => {
-                            let err = e.downcast_ref::<ResourceError>().unwrap();
-                            tracing::info!("resources unavailable: {}", err);
-                            sleep(Duration::from_millis(500)).await;
-
-                            // Return the popped program_id back to pending queue.
-                            state.pending_programs.push_back((tx_hash, program_id));
-                            continue 'SCHEDULING_LOOP;
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "tx {} - failed to start program {}: {e}",
-                                tx_hash,
-                                program_id
-                            );
-                            // Return the popped program_id back to pending queue.
-                            state.pending_programs.push_back((tx_hash, program_id));
-                            continue 'SCHEDULING_LOOP;
-                        }
-                    }
-                }
-            }
-
-            let mut task = match self.pick_task().await {
-                Some(t) => {
-                    tracing::debug!("task {}/{} scheduled for running", t.id, t.tx);
-                    t
-                }
-                None => {
-                    sleep(Duration::from_millis(100)).await;
-                    continue;
-                }
-            };
-
-            // Copy Task file to VM workspace
-            // Validate that everything is ok before starting the task.
-            for file in task.files.iter() {
-                if let Err(err) = file
-                    .copy_file_for_vm_exe(&self.data_directory, task.tx)
-                    .await
-                {
-                    tracing::error!(
-                        "An error occurs during Tx:{} task file copy for VM execution {err}",
-                        task.tx
-                    );
-                    if let Err(err) = self.database.mark_tx_executed(&task.tx).await {
-                        tracing::error!(
-                            "failed to update transaction.executed => true - tx.hash: {}",
-                            task.tx
-                        );
-                    }
-                    continue;
-                }
-            }
-
-            // Push the task into program's work queue.
-            let mut state = self.state.lock().await;
-            if let Some(program_task_queue) = state.task_queue.get_mut(&task.tx) {
-                program_task_queue.push_back((task.clone(), Instant::now()));
-            } else {
-                let mut queue = VecDeque::new();
-                queue.push_back((task.clone(), Instant::now()));
-                state.task_queue.insert(task.tx, queue);
-            }
-
-            // Start the program.
-            match state
-                .program_manager
-                .start_program(task.tx, task.program_id, None)
-                .await
-            {
-                Ok(p) => {
-                    state.running_vms.insert(task.tx, p);
-                }
-                Err(ref err) => {
-                    if let Some(err) = err.downcast_ref::<ProgramError>() {
-                        let ProgramError::ProgramNotFound(msg) = err;
-                        tracing::error!("failed to schedule task {}: {}", task.id.to_string(), msg);
-
-                        // TODO: Persist failed task state.
-                        task.state = TaskState::Failed;
-
-                        // Drop the program's task queue. The program's not
-                        // there so no need to have queue for it either.
-                        let program_id = &task.program_id.clone();
-                        state.task_queue.remove(&task.tx);
-                    }
-
-                    self.reschedule(&task).await?;
-                    tracing::warn!("task {} rescheduled: {}", task.id.to_string(), err);
-                    continue;
-                }
-            }
-        }
-    }
-
-    async fn pick_task(&self) -> Option<Task> {
-        let state = self.state.lock().await;
-
-        // Acquire write lock.
-        let mut mempool = state.mempool.write().await;
-
-        // Check if next tx is ready for processing?
-
-        match mempool.next() {
-            Some(tx) => match self.workflow_engine.next_task(&tx).await {
-                Ok(res) => res,
-                Err(e) if e.is::<WorkflowError>() => {
-                    let err = e.downcast_ref::<WorkflowError>();
-                    match err {
-                        Some(WorkflowError::IncompatibleTransaction(_)) => {
-                            tracing::debug!("{}", e);
-                            None
-                        }
-                        _ => {
-                            tracing::error!(
-                                "workflow error, failed to compute next task for tx:{}: {}",
-                                tx.hash,
-                                e
-                            );
-                            None
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("failed to compute next task for tx:{}: {}", tx.hash, e);
-                    None
-                }
-            },
-            None => None,
-        }
-    }
-
-    async fn reschedule(&self, task: &Task) -> Result<()> {
-        // The task is already pending in program's work queue. Push program ID
-        // to pending programs queue to wait available resources.
-        self.state
-            .lock()
-            .await
-            .pending_programs
-            .push_back((task.tx, task.program_id));
-        Ok(())
-    }
-
-    async fn reap_zombies(&self) {
-        let mut state = self.state.lock().await;
-
-        let mut zombies = vec![];
-        for task in state.running_tasks.values() {
-            if let Some(vm_handle) = state.running_vms.get(&task.task.tx) {
-                tracing::trace!(
-                    "inspecting if VM for task id {} is still alive",
-                    task.task.id
-                );
-                match vm_handle.is_alive().await {
-                    Ok(true) => {
-                        if task.task_started.elapsed() > MAX_VM_RUN_TIME {
-                            tracing::trace!("VM is still alive but has exceeded MAX_VM_RUN_TIME ({:#?} > {:#?}) - terminating it.", task.task_started.elapsed(), MAX_VM_RUN_TIME);
-                            zombies.push(task.task.tx);
-                        } else {
-                            tracing::trace!(
-                                "VM is still alive (run time: {:#?}).",
-                                task.task_started.elapsed()
-                            );
-                            continue; // All good
-                        }
-                    }
-                    Ok(false) => {
-                        // VM is not running anymore.
-                        tracing::warn!(
-                            "VM {} running for task (id: {}, tx hash: {}) has stopped",
-                            vm_handle.vm_id(),
-                            task.task.id,
-                            task.task.tx
-                        );
-                        zombies.push(task.task.tx);
-                    }
-                    Err(err) => {
-                        tracing::error!("failed to query VM state for {} running task (id: {}, tx hash: {}): {}", vm_handle.vm_id(), task.task.id, task.task.tx, err);
-                        zombies.push(task.task.tx);
-                    }
-                }
-            } else {
-                // VM doesn't exist. Shouldn't happen...
-                tracing::error!("found task (id: {}, tx hash: {}) running on VM but not the corresponding running VM", task.task.id, task.task.tx);
-                zombies.push(task.task.tx);
-            }
-        }
-
-        while let Some(task_tx) = zombies.pop() {
-            tracing::debug!("reaping stopped task (tx: {}) running on VM", task_tx,);
-
-            // For each zombie task:
-            // - Stop the VM.
-            // - Remove the VM from the `running_vms`.
-            // - Remove the task from the `running_tasks`.
-            //
-            if let Some(vm_handle) = state.running_vms.remove(&task_tx) {
-                if let Err(err) = state.program_manager.stop_program(vm_handle).await {
-                    tracing::error!("failed to stop VMvm_handle {}", err);
-                }
-            }
-
-            //TODO cancel associated Tx
-            state.running_tasks.remove(&task_tx);
-        }
-
-        // Now, reap VMs that don't have running task.
-        let mut zombies = vec![];
-        for (tx_hash, vm_handle) in state.running_vms.iter() {
-            if !state.running_tasks.contains_key(tx_hash) {
-                // XXX: Following is not 100% correct. It checks the runtime
-                // from the very beginning of the whole VM's start-up, which
-                // is not the same as idle runtime. However, right now each VM
-                // is expected to be run only for one task and this check is
-                // not visited until there's no running task for the given VM
-                // so it's ought to be ok.
-                if vm_handle.run_time() > MAX_VM_IDLE_RUN_TIME {
-                    tracing::debug!(
-                        "VM {} has been running idle for {:#?}; scheduling for termination",
-                        vm_handle.vm_id(),
-                        vm_handle.run_time()
-                    );
-                    zombies.push(*tx_hash);
-                }
-            }
-        }
-
-        while let Some(tx_hash) = zombies.pop() {
-            tracing::debug!("reaping idle VM for tx {}", tx_hash);
-
-            if let Some(idx) = state.running_vms.get(&tx_hash) {
-                if let Some(vm_handle) = state.running_vms.remove(&tx_hash) {
-                    if let Err(err) = state.program_manager.stop_program(vm_handle).await {
-                        tracing::error!("failed to stop VM  for Tx {}: {}", tx_hash, err);
-                    }
-                }
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl TaskManager for Scheduler {
-    async fn get_running_task(&self, tx_hash: Hash) -> Option<Task> {
-        let state = self.state.lock().await;
-        state.running_tasks.get(&tx_hash).map(|t| t.task.clone())
-    }
-
-    async fn get_pending_task(&self, tx_hash: Hash) -> Option<Task> {
-        tracing::debug!("tx {} running requests for new task", tx_hash,);
-
-        // Ensure that the VM requesting for a task is not already executing one!
-        let mut state = self.state.lock().await;
-        if let Some(running_task) = state.running_tasks.get(&tx_hash) {
-            // A VM that is already running a task, requests for a new one.
-            // Mark the existing task as executed and stop the VM.
-            tracing::info!(
-                "task {} has been running {}sec but found to be orphaned. marking it as executed.",
-                running_task.task.id,
-                running_task.task_started.elapsed().as_secs()
-            );
-
-            tracing::debug!("terminating VM running tx {}", tx_hash);
-
-            if let Some(program_handle) = state.running_vms.remove(&tx_hash) {
-                if let Err(err) = state.program_manager.stop_program(program_handle).await {
-                    tracing::error!("failed to stop program {}: {}", tx_hash, err);
-                }
-            }
-
-            return None;
-        }
-
-        if let Some(task_queue) = state.task_queue.get_mut(&tx_hash) {
-            if let Some((task, scheduled)) = task_queue.pop_front() {
-                tracing::debug!("task {} found for tx {} running", task.id, tx_hash,);
-                tracing::info!(
-                    "task {} started in {}ms",
-                    task.id,
-                    scheduled.elapsed().as_millis()
-                );
-
-                state.running_tasks.insert(
-                    task.tx,
-                    RunningTask {
-                        task: task.clone(),
-                        task_scheduled: scheduled,
-                        task_started: Instant::now(),
-                    },
-                );
-
-                return Some(task.clone());
-            }
-        }
-
-        None
-    }
-
-    async fn submit_result(
+    pub async fn run2(
         &self,
-        tx_hash: Hash,
-        program: Hash,
-        result: grpc::task_result_request::Result,
-    ) -> Result<(), String> {
-        tracing::debug!("submit_result tx:{tx_hash}  result:{result:#?}");
+        vm_provider: Qemu,
+        resource_manager: ResourceManager,
+        running_task: ShareVMRunningTaskMap,
+        mempool: Arc<RwLock<Mempool>>,
+        mut result_receiver: tokio::sync::mpsc::Receiver<(
+            Task,
+            u32,
+            grpc::task_result_request::Result,
+        )>,
+        mut exec_receiver: tokio::sync::mpsc::Receiver<Transaction<Validated>>,
+    ) -> Result<()> {
+        let mut start_vm_futures = FuturesUnordered::new();
+        let mut torun_task_futures = FuturesUnordered::new();
+        let mut result_vm_futures = FuturesUnordered::new();
+        let mut task_manager = ProgramManager::new(
+            self.database.clone(),
+            vm_provider,
+            resource_manager,
+            running_task,
+        );
 
-        let mut state = self.state.lock().await;
-        if let Some(running_task) = state.running_tasks.remove(&tx_hash) {
-            tracing::info!(
-                "task of Tx {} finished in {}sec",
-                running_task.task.tx,
-                running_task.task_started.elapsed().as_secs()
-            );
+        let mut running_task: HashMap<Hash, VMHandle> = HashMap::new();
 
-            if let Err(err) = self.database.mark_tx_executed(&running_task.task.tx).await {
-                tracing::error!(
-                    "failed to update transaction.executed => true - tx.hash: {}",
-                    &running_task.task.tx
-                );
-            }
+        //Reap zombies every  second.
+        let mut reap_zombies_timer = tokio::time::interval(Duration::from_millis(1000));
 
-            match result {
-                grpc::task_result_request::Result::Task(result) => {
-                    // Handle tx execution's result files so that they are available as an input for next task if needed.
-                    let executed_files: Vec<(TaskVmFile<VmOutput>, TxFile<Output>)> = result
-                        .files
-                        .into_iter()
-                        .map(|file| {
-                            let vm_file =
-                                TaskVmFile::<VmOutput>::new(file.path.to_string(), tx_hash);
-                            let dest = TxFile::<Output>::new(
-                                file.path,
-                                self.http_download_host.clone(),
-                                file.checksum[..].into(),
+        loop {
+            select! {
+                //Everify Zombies  VM.
+                _ = reap_zombies_timer.tick() => {
+                    //TODO.
+                }
+
+                //process task execution result
+                Some((task, cid, result)) = result_receiver.recv() => {
+                    let result_jh = tokio::spawn({
+                        let http_download_host = self.http_download_host.clone();
+                        let data_directory = self.data_directory.clone();
+                        let node_key = self.node_key.clone();
+                        let database = self.database.clone();
+                        async move {
+                            let tx_hash = task.tx;
+                            let res = Scheduler::submit_result(task, cid, result, &http_download_host, &data_directory, node_key, &database).await;
+
+                            //TODO put inn the right place. VM exe error doesn't remove workplace
+                            // Clean VM `<tx_hash>/workspace` data.
+                            let workspace_path = TaskVmFile::get_workspace_path(&data_directory, tx_hash);
+                            let to_remove_path = workspace_path.parent().unwrap(); //unwrap always a parent.
+                            if let Err(err) = std::fs::remove_dir_all(to_remove_path) {
+                                tracing::warn!(
+                                    "Execution workspace:{:?} for Tx:{tx_hash} didn't clean correctly because {err}",
+                                    to_remove_path,
+                                );
+                            }
+                            res
+                        }});
+                    result_vm_futures.push(result_jh);
+                }
+
+                //End task execution.
+                Some(Ok((task, cid, res)))= result_vm_futures.next() => {
+                    //Manage VM
+                    let resource_allocation = match running_task.remove(&task.tx) {
+                        Some(mut vm_handle) =>  {
+                            tracing::info!(
+                                "task of Tx {} finished in {}sec",
+                                task.tx,
+                                vm_handle.start_time.elapsed().as_secs()
                             );
-                            (vm_file, dest)
-                        })
-                        .collect();
-
-                    //TODO -Verify that all expected files has been generated.
-
-                    let new_tx_files: Vec<TxFile<Output>> = executed_files
-                        .iter()
-                        .map(|(_, file)| file)
-                        .cloned()
-                        .collect();
-                    let nonce = rand::thread_rng().next_u64();
-                    let tx = match running_task.task.kind {
-                        TaskKind::Proof => Transaction::new(
-                            Payload::Proof {
-                                parent: running_task.task.tx,
-                                prover: program,
-                                proof: result.data,
-                                files: new_tx_files,
-                            },
-                            &self.node_key,
-                        ),
-                        TaskKind::Verification => Transaction::new(
-                            Payload::Verification {
-                                parent: running_task.task.tx,
-                                verifier: program,
-                                verification: result.data,
-                                files: new_tx_files,
-                            },
-                            &self.node_key,
-                        ),
-                        TaskKind::PoW => {
-                            todo!("proof of work tasks not implemented yet");
+                            let ressource_allocation = Some(vm_handle.qemu_vm_handle.resource_allocation.clone());
+                            tokio::task::spawn_blocking(move || {
+                                let cid = vm_handle.qemu_vm_handle.cid;
+                                if let Err(err) = vm_handle.qemu_vm_handle
+                                    .child
+                                    .as_mut()
+                                    .ok_or(std::io::Error::other(
+                                        "No child process defined for this handle",
+                                    ))
+                                    .and_then(|p| {
+                                        p.kill()?;
+                                        p.wait()
+                                })  {
+                                    tracing::error!("Error during VM kill:{err}");
+                                }
+                            });
+                            ressource_allocation
                         }
-                        TaskKind::Nop => {
-                            panic!(
-                                "impossible to receive result from a task ({}/{}) with task.kind == Nop",
-                                running_task.task.id, running_task.task.tx
-                            );
+                        None => {
+                            //the start VM task result hasn't been processed.
+                            //The VM execute to fast.
+                            //reschedule the result.
+                            tracing::warn!("Running VM notify too early Tx result: {} cid:{}", task.tx, cid);
+                            result_vm_futures.push(tokio::spawn(async move{
+                                sleep(Duration::from_millis(100)).await;
+                                (task, cid, res)
+                            }));
+                            continue;
+                        },
+                    };
+                    task_manager.end_task(task.tx, cid, resource_allocation.as_ref()).await;
+
+                    //manage Tx execution result
+                    match res {
+                        Ok(Some(tx)) => {
+                            // Send tx to validation process.
+                            if let Err(err) = self.tx_sender.send_tx(tx).await {
+                                tracing::error!("failed to send Tx result to validation process: {}", err)
+                            };
+                        }
+                        Ok(None) => (),
+                        Err(err) => {
+                            tracing::error!("Error during submit VM execution result:{err}");
+                        }
+                    }
+                }
+
+                //get a task from mempool if any.
+                Some(tx) = exec_receiver.recv() => {
+                    if let Some(task) = self.get_task_from_tx(&tx).await {
+                        torun_task_futures.push(tokio::spawn(async move{task}));
+                    }
+                }
+                Some(Ok(task)) = torun_task_futures.next() => {
+                    tracing::debug!("task {}/{} scheduled for running", task.id, task.tx);
+                    let qemu_vm_handle = match task_manager.prepare_task_execution(&task).await {
+                        Ok(handle) => handle,
+                        Err(err) => {
+                            match err {
+                                ExecuteTaskError::NotEnoughResources(_) => {
+                                    tracing::info!("{err} reschedule");
+                                    let task_jh = tokio::spawn(
+                                        async move {
+                                            sleep(Duration::from_millis(500)).await;
+                                            task
+                                        }
+                                    );
+                                    //reshedule the task.
+                                    torun_task_futures.push(task_jh);
+                                }
+                                _ => {
+                                    tracing::error!("{err} Abort Tx:{}", task.tx);
+                                    if let Err(err) = self.database.mark_tx_executed(&task.tx).await
+                                    {
+                                        tracing::error!(
+                                            "failed to update transaction.executed => true - tx.hash: {}",
+                                            task.tx
+                                        );
+                                    }
+                                }
+                            }
+                            continue;
                         }
                     };
-                    tracing::info!("Submit result Tx created:{}", tx.hash.to_string());
 
-                    // Move tx file from execution Tx path to new Tx path
-                    for (source_file, dest_file) in executed_files {
-                        move_vmfile(&source_file, &dest_file, &self.data_directory, tx.hash)
-                            .await.map_err(|err| format!("failed to move excution file from: {source_file:?} to: {dest_file:?} error: {err}"))?;
+                    let validate_jh = tokio::spawn({
+                        let data_directory = self.data_directory.clone();
+                        let log_directory = self.log_directory.clone();
+                        async move {
+                            ProgramManager::start_task(task, qemu_vm_handle, None, &data_directory, &log_directory).await
+                        }});
+                    start_vm_futures.push(validate_jh);
+                }
+                Some(Ok(res)) = start_vm_futures.next() =>  {
+                    match res {
+                        Ok(vm_handle) => {
+                            running_task.insert(vm_handle.qemu_vm_handle.tx_hash, vm_handle);
+                        }
+                        Err(err) => {
+                            tracing::error!("Could start the VM:{err}");
+                            match err {
+                                ExecuteTaskError::InputFileCopyFailError(tx_hash, cid, _) => {
+                                    task_manager.end_task(tx_hash, cid, None).await;
+                                },
+                                _ => {
+
+                                }
+                            }
+
+                        }
                     }
-
-                    // Send tx to validation process.
-                    self.tx_sender.send_tx(tx).await.map_err(|err| {
-                        format!("failed to send Tx result to validation process: {}", err)
-                    })?;
-                }
-                grpc::task_result_request::Result::Error(error) => {
-                    tracing::warn!("Error during Tx:{tx_hash} execution:{error:?}");
                 }
             }
-
-            tracing::debug!("terminating VM running program {}", program);
-
-            match state.running_vms.remove(&tx_hash) {
-                Some(program_handle) => {
-                    state
-                        .program_manager
-                        .stop_program(program_handle)
-                        .await
-                        .map_err(|err| format!("failed to stop program {}: {}", program, err))?;
-                }
-                None => tracing::warn!("Running VM not found for a Tx result: {tx_hash}"),
-            }
-            Ok(())
-        } else {
-            Err(format!("submit_result task:{tx_hash} not found."))
         }
     }
+
+    async fn get_task_from_tx(&self, tx: &Transaction<Validated>) -> Option<Task> {
+        match self.workflow_engine.next_task(tx).await {
+            Ok(res) => res,
+            Err(e) if e.is::<WorkflowError>() => {
+                let err = e.downcast_ref::<WorkflowError>();
+                match err {
+                    Some(WorkflowError::IncompatibleTransaction(_)) => {
+                        tracing::debug!("{}", e);
+                        None
+                    }
+                    _ => {
+                        tracing::error!(
+                            "workflow error, failed to compute next task for tx:{}: {}",
+                            tx.hash,
+                            e
+                        );
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("failed to compute next task for tx:{}: {}", tx.hash, e);
+                None
+            }
+        }
+    }
+    async fn submit_result(
+        task: Task,
+        cid: u32,
+        result: grpc::task_result_request::Result,
+        http_download_host: &str,
+        data_directory: &PathBuf,
+        node_key: SecretKey,
+        database: &Database,
+    ) -> (
+        Task,
+        u32,
+        Result<Option<Transaction<Created>>, ExecuteTaskError>,
+    ) {
+        tracing::debug!(
+            "submit_result tx:{} cid:{}  result:{result:#?}",
+            task.tx,
+            cid
+        );
+
+        if let Err(err) = database.mark_tx_executed(&task.tx).await {
+            tracing::error!(
+                "failed to update transaction.executed => true - tx.hash: {}",
+                &task.tx
+            );
+        }
+
+        match result {
+            grpc::task_result_request::Result::Task(result) => {
+                // Handle tx execution's result files so that they are available as an input for next task if needed.
+                let executed_files: Vec<(TaskVmFile<VmOutput>, TxFile<Output>)> = result
+                    .files
+                    .into_iter()
+                    .map(|file| {
+                        let vm_file = TaskVmFile::<VmOutput>::new(file.path.to_string(), task.tx);
+                        let dest = TxFile::<Output>::new(
+                            file.path,
+                            http_download_host.to_string(),
+                            file.checksum[..].into(),
+                        );
+                        (vm_file, dest)
+                    })
+                    .collect();
+
+                //TODO -Verify that all expected files has been generated.
+
+                let new_tx_files: Vec<TxFile<Output>> = executed_files
+                    .iter()
+                    .map(|(_, file)| file)
+                    .cloned()
+                    .collect();
+                let nonce = rand::thread_rng().next_u64();
+                let tx = match task.kind {
+                    TaskKind::Proof => Transaction::new(
+                        Payload::Proof {
+                            parent: task.tx,
+                            prover: task.program_id,
+                            proof: result.data,
+                            files: new_tx_files,
+                        },
+                        &node_key,
+                    ),
+                    TaskKind::Verification => Transaction::new(
+                        Payload::Verification {
+                            parent: task.tx,
+                            verifier: task.program_id,
+                            verification: result.data,
+                            files: new_tx_files,
+                        },
+                        &node_key,
+                    ),
+                    TaskKind::PoW => {
+                        todo!("proof of work tasks not implemented yet");
+                    }
+                    TaskKind::Nop => {
+                        panic!(
+                                "impossible to receive result from a task ({}/{}) with task.kind == Nop",
+                                task.id, task.tx
+                            );
+                    }
+                };
+                tracing::info!("Submit result Tx created:{}", tx.hash.to_string());
+
+                // Move tx file from execution Tx path to new Tx path
+                for (source_file, dest_file) in executed_files {
+                    if let Err(err) =
+                        move_vmfile(&source_file, &dest_file, data_directory, tx.hash).await
+                    {
+                        return (task, cid, Err(ExecuteTaskError::SubmitResultError(
+                                format!("failed to move excution file from: {source_file:?} to: {dest_file:?} error: {err}")
+                            )));
+                    }
+                }
+
+                tracing::debug!("terminating VM running program {}", task.program_id);
+                (task, cid, Ok(Some(tx)))
+            }
+            grpc::task_result_request::Result::Error(error) => {
+                tracing::warn!("Error during Tx:{} execution:{error:?}", task.tx);
+                (task, cid, Ok(None))
+            }
+        }
+    }
+
+    //     async fn reap_zombies(&self) {
+    //         let mut state = self.state.lock().await;
+
+    //         let mut zombies = vec![];
+    //         for task in state.running_tasks.values() {
+    //             if let Some(vm_handle) = state.running_vms.get(&task.task.tx) {
+    //                 tracing::trace!(
+    //                     "inspecting if VM for task id {} is still alive",
+    //                     task.task.id
+    //                 );
+    //                 match vm_handle.is_alive().await {
+    //                     Ok(true) => {
+    //                         if task.task_started.elapsed() > MAX_VM_RUN_TIME {
+    //                             tracing::trace!("VM is still alive but has exceeded MAX_VM_RUN_TIME ({:#?} > {:#?}) - terminating it.", task.task_started.elapsed(), MAX_VM_RUN_TIME);
+    //                             zombies.push(task.task.tx);
+    //                         } else {
+    //                             tracing::trace!(
+    //                                 "VM is still alive (run time: {:#?}).",
+    //                                 task.task_started.elapsed()
+    //                             );
+    //                             continue; // All good
+    //                         }
+    //                     }
+    //                     Ok(false) => {
+    //                         // VM is not running anymore.
+    //                         tracing::warn!(
+    //                             "VM {} running for task (id: {}, tx hash: {}) has stopped",
+    //                             vm_handle.vm_id(),
+    //                             task.task.id,
+    //                             task.task.tx
+    //                         );
+    //                         zombies.push(task.task.tx);
+    //                     }
+    //                     Err(err) => {
+    //                         tracing::error!("failed to query VM state for {} running task (id: {}, tx hash: {}): {}", vm_handle.vm_id(), task.task.id, task.task.tx, err);
+    //                         zombies.push(task.task.tx);
+    //                     }
+    //                 }
+    //             } else {
+    //                 // VM doesn't exist. Shouldn't happen...
+    //                 tracing::error!("found task (id: {}, tx hash: {}) running on VM but not the corresponding running VM", task.task.id, task.task.tx);
+    //                 zombies.push(task.task.tx);
+    //             }
+    //         }
+
+    //         while let Some(task_tx) = zombies.pop() {
+    //             tracing::debug!("reaping stopped task (tx: {}) running on VM", task_tx,);
+
+    //             // For each zombie task:
+    //             // - Stop the VM.
+    //             // - Remove the VM from the `running_vms`.
+    //             // - Remove the task from the `running_tasks`.
+    //             //
+    //             if let Some(vm_handle) = state.running_vms.remove(&task_tx) {
+    //                 if let Err(err) = state.program_manager.stop_program(vm_handle).await {
+    //                     tracing::error!("failed to stop VMvm_handle {}", err);
+    //                 }
+    //             }
+
+    //             //TODO cancel associated Tx
+    //             state.running_tasks.remove(&task_tx);
+    //         }
+
+    //         // Now, reap VMs that don't have running task.
+    //         let mut zombies = vec![];
+    //         for (tx_hash, vm_handle) in state.running_vms.iter() {
+    //             if !state.running_tasks.contains_key(tx_hash) {
+    //                 // XXX: Following is not 100% correct. It checks the runtime
+    //                 // from the very beginning of the whole VM's start-up, which
+    //                 // is not the same as idle runtime. However, right now each VM
+    //                 // is expected to be run only for one task and this check is
+    //                 // not visited until there's no running task for the given VM
+    //                 // so it's ought to be ok.
+    //                 if vm_handle.run_time() > MAX_VM_IDLE_RUN_TIME {
+    //                     tracing::debug!(
+    //                         "VM {} has been running idle for {:#?}; scheduling for termination",
+    //                         vm_handle.vm_id(),
+    //                         vm_handle.run_time()
+    //                     );
+    //                     zombies.push(*tx_hash);
+    //                 }
+    //             }
+    //         }
+
+    //         while let Some(tx_hash) = zombies.pop() {
+    //             tracing::debug!("reaping idle VM for tx {}", tx_hash);
+
+    //             if let Some(idx) = state.running_vms.get(&tx_hash) {
+    //                 if let Some(vm_handle) = state.running_vms.remove(&tx_hash) {
+    //                     if let Err(err) = state.program_manager.stop_program(vm_handle).await {
+    //                         tracing::error!("failed to stop VM  for Tx {}: {}", tx_hash, err);
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //     }
 }
+
+// #[async_trait]
+// impl TaskManager for Scheduler {
+// async fn get_running_task(&self, tx_hash: Hash) -> Option<Task> {
+//     let state = self.state.lock().await;
+//     state.running_tasks.get(&tx_hash).map(|t| t.task.clone())
+// }
+
+// async fn get_pending_task(&self, tx_hash: Hash) -> Option<Task> {
+//     tracing::debug!("tx {} running requests for new task", tx_hash,);
+
+//     // Ensure that the VM requesting for a task is not already executing one!
+//     let mut state = self.state.lock().await;
+//     if let Some(running_task) = state.running_tasks.get(&tx_hash) {
+//         // A VM that is already running a task, requests for a new one.
+//         // Mark the existing task as executed and stop the VM.
+//         tracing::info!(
+//             "task {} has been running {}sec but found to be orphaned. marking it as executed.",
+//             running_task.task.id,
+//             running_task.task_started.elapsed().as_secs()
+//         );
+
+//         tracing::debug!("terminating VM running tx {}", tx_hash);
+
+//         if let Some(program_handle) = state.running_vms.remove(&tx_hash) {
+//             if let Err(err) = state.program_manager.stop_program(program_handle).await {
+//                 tracing::error!("failed to stop program {}: {}", tx_hash, err);
+//             }
+//         }
+
+//         return None;
+//     }
+
+//     if let Some(task_queue) = state.task_queue.get_mut(&tx_hash) {
+//         if let Some((task, scheduled)) = task_queue.pop_front() {
+//             tracing::debug!("task {} found for tx {} running", task.id, tx_hash,);
+//             tracing::info!(
+//                 "task {} started in {}ms",
+//                 task.id,
+//                 scheduled.elapsed().as_millis()
+//             );
+
+//             state.running_tasks.insert(
+//                 task.tx,
+//                 RunningTask {
+//                     task: task.clone(),
+//                     task_scheduled: scheduled,
+//                     task_started: Instant::now(),
+//                 },
+//             );
+
+//             return Some(task.clone());
+//         }
+//     }
+
+//     None
+// }
+
+//}

--- a/crates/node/src/scheduler/program_manager.rs
+++ b/crates/node/src/scheduler/program_manager.rs
@@ -1,14 +1,18 @@
-use eyre::Result;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
-use thiserror::Error;
-use tokio::sync::Mutex as TMutex;
-
 use crate::scheduler::resource_manager::{ResourceAllocation, ResourceManager};
+use crate::scheduler::ExecuteTaskError;
 use crate::storage::Database;
 use crate::types::program::ResourceRequest;
 use crate::types::Hash;
-use crate::vmm::{Provider, VMHandle, VMId};
+use crate::vmm::qemu::Qemu;
+use crate::vmm::vm_server::ShareVMRunningTaskMap;
+use crate::vmm::QEMUVMHandle;
+use crate::vmm::VMHandle;
+use eyre::Result;
+use gevulot_node::types::Task;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Error, Debug)]
@@ -20,12 +24,13 @@ pub enum ProgramError {
 pub struct ProgramHandle {
     resource_allocation: ResourceAllocation,
     vm_handle: VMHandle,
+    task: Task,
 }
 
 impl ProgramHandle {
-    pub fn vm_id(&self) -> Arc<dyn VMId> {
-        self.vm_handle.vm_id()
-    }
+    // pub fn vm_id(&self) -> Arc<dyn VMId> {
+    //     self.vm_handle.vm_id()
+    // }
 
     pub async fn is_alive(&self) -> Result<bool> {
         self.vm_handle.is_alive().await
@@ -38,51 +43,108 @@ impl ProgramHandle {
 
 pub struct ProgramManager {
     storage: Arc<Database>,
-    resource_manager: Arc<Mutex<ResourceManager>>,
-    vm_provider: Arc<TMutex<dyn Provider>>,
+    vm_provider: Qemu,
+    resource_manager: ResourceManager,
+    running_task: ShareVMRunningTaskMap,
 }
 
 impl ProgramManager {
     pub fn new(
         storage: Arc<Database>,
-        vm_provider: Arc<TMutex<dyn Provider>>,
-        resource_manager: Arc<Mutex<ResourceManager>>,
+        vm_provider: Qemu,
+        resource_manager: ResourceManager,
+        running_task: ShareVMRunningTaskMap,
     ) -> Self {
         Self {
             storage,
             resource_manager,
             vm_provider,
+            running_task,
         }
     }
 
-    pub async fn start_program(
+    pub async fn prepare_task_execution(
         &mut self,
-        tx_hash: Hash,
-        program_id: Hash,
-        limits: Option<ResourceRequest>,
-    ) -> Result<ProgramHandle> {
-        let program = match self.storage.find_program(&program_id).await? {
-            Some(program) => program,
-            None => return Err(ProgramError::ProgramNotFound(program_id.to_string()).into()),
+        task: &Task,
+    ) -> Result<QEMUVMHandle, ExecuteTaskError> {
+        let ressource_request: Option<ResourceRequest> = Default::default();
+        let program = self
+            .storage
+            .find_program(&task.program_id)
+            .await
+            .map_err(|err| ExecuteTaskError::DatabaseError(err.to_string()))?
+            .ok_or(ExecuteTaskError::ProgramNotFound(task.program_id))?;
+
+        let ressource_request = ressource_request.or(program.limits).unwrap_or_default();
+        let resource_allocation = self.resource_manager.try_allocate(&ressource_request)?;
+
+        let cid = self.vm_provider.allocate_cid();
+
+        let qemu_vm_handle = QEMUVMHandle {
+            child: None,
+            cid,
+            tx_hash: task.tx,
+            resource_allocation,
+            program,
         };
 
-        let req = limits.unwrap_or(program.limits.unwrap_or(ResourceRequest::default()));
-        let resource_allocation =
-            ResourceManager::try_allocate(self.resource_manager.clone(), &req)?;
-        let vm_handle = self
-            .vm_provider
-            .lock()
-            .await
-            .start_vm(tx_hash, program, req)
-            .await?;
+        // Must VM must be registered before start, because when the VM starts,
+        // the program in it starts immediately and queries for task, which
+        // requires the VM to be registered for identification.
+        self.running_task.insert_task(cid, task.clone()).await;
+        Ok(qemu_vm_handle)
+    }
 
-        Ok(ProgramHandle {
-            resource_allocation,
-            vm_handle,
+    pub async fn start_task(
+        task: Task,
+        mut qemu_vm_handle: QEMUVMHandle,
+        gpu_devices: Option<String>,
+        data_directory: &PathBuf, //&self.config.data_directory
+        log_directory: &PathBuf,
+    ) -> Result<VMHandle, ExecuteTaskError> {
+        // Copy Task file to VM workspace
+        // Validate that everything is ok before starting the task.
+        for file in &task.files {
+            file.copy_file_for_vm_exe(data_directory, task.tx)
+                .await
+                .map_err(|err| {
+                    ExecuteTaskError::InputFileCopyFailError(
+                        task.tx,
+                        qemu_vm_handle.cid,
+                        format!("{} : {err}", file.vm_file_path()),
+                    )
+                })?;
+        }
+
+        //start the VM
+        let (vm_process, vm_client, start_time) = Qemu::start_vm(
+            qemu_vm_handle.cid,
+            &qemu_vm_handle.resource_allocation,
+            gpu_devices,
+            data_directory,
+            log_directory,
+            task.tx,
+            &qemu_vm_handle.program,
+        )
+        .await?;
+
+        qemu_vm_handle.child = Some(vm_process);
+        Ok(VMHandle {
+            qemu_vm_handle,
+            start_time,
+            vm_client: Arc::new(vm_client),
         })
     }
 
-    pub async fn stop_program(&mut self, prg_handle: ProgramHandle) -> Result<()> {
-        self.vm_provider.lock().await.stop_vm(prg_handle.vm_handle)
+    pub async fn end_task(
+        &mut self,
+        tx_hash: Hash,
+        cid: u32,
+        resource_allocation: Option<&ResourceAllocation>,
+    ) {
+        if let Some(resource_allocation) = resource_allocation {
+            self.resource_manager.free(resource_allocation);
+        }
+        self.vm_provider.release_cid(cid);
     }
 }

--- a/crates/node/src/scheduler/program_manager.rs
+++ b/crates/node/src/scheduler/program_manager.rs
@@ -147,4 +147,8 @@ impl ProgramManager {
         }
         self.vm_provider.release_cid(cid);
     }
+
+    pub async fn remove_zombie_task_with_cid(&self, cid: u32) -> Option<Task> {
+        self.running_task.remove_task_with_cid(cid).await
+    }
 }

--- a/crates/node/src/scheduler/resource_manager.rs
+++ b/crates/node/src/scheduler/resource_manager.rs
@@ -75,6 +75,8 @@ impl ResourceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
 
     #[test]
     fn test_try_allocate_succeeds() {

--- a/crates/node/src/vmm/vm_server.rs
+++ b/crates/node/src/vmm/vm_server.rs
@@ -80,6 +80,10 @@ impl ShareVMRunningTaskMap {
         }
     }
 
+    pub async fn remove_task_with_cid(&self, cid: u32) -> Option<Task> {
+        self.task_list.lock().await.remove(&cid)
+    }
+
     pub async fn len(&self) -> usize {
         self.task_list.lock().await.len()
     }

--- a/crates/tests/e2e-tests/src/main.rs
+++ b/crates/tests/e2e-tests/src/main.rs
@@ -56,13 +56,13 @@ async fn main() -> Result<()> {
     .await
     .expect("deploy");
 
-    for nonce in 1..2 {
+    for nonce in 1..400 {
         send_proving_task(&client, &key, nonce, &prover_hash, &verifier_hash)
             .await
             .expect("send proving task");
     }
 
-    sleep(Duration::from_secs(360)).await;
+    //sleep(Duration::from_secs(360)).await;
 
     Ok(())
 }

--- a/crates/tests/e2e-tests/src/main.rs
+++ b/crates/tests/e2e-tests/src/main.rs
@@ -56,10 +56,11 @@ async fn main() -> Result<()> {
     .await
     .expect("deploy");
 
-    for nonce in 1..400 {
+    for nonce in 1..100 {
         send_proving_task(&client, &key, nonce, &prover_hash, &verifier_hash)
             .await
             .expect("send proving task");
+        sleep(Duration::from_millis(10)).await;
     }
 
     //sleep(Duration::from_secs(360)).await;


### PR DESCRIPTION
I've added the unexecuted Tx verification at startup. Now, unexecuted Tx are executed.

I've put a zombies VM detection. I use the `client.is_alive()` like the current scheduler.

From my test I see that zombies VM always return true to this call and stay running indefinitely using all the CPU. From the VM logs, the kernel has crashed, but it seems to still running.
They are stopped after the MAX_VM_RUN_TIME, but It takes time.

So the current implementation halt crashed VM only after the  MAX_VM_RUN_TIME time. I didn't manage to have a VM that crash and doesn't seem alive.

I think to do a better Zombie detection we can implement 2 things:
 * detected that the VM didn't call `get_task() ` after a certain time. I didn't do the test, but it seems that the VM crash early.
 * Add some activity detection using the file system. In the shim SDK, we can create a task that looks at a file and, if it's not present, recreate it.   This way, by removing the file, we can detect if it's recreated or not.
 
 From my test, the number of zombie VM depends on the node CPU usage.

It's a raw implementation to test. I think we can dissociate the task scheduling part and the VM management part to simplify the loop and the VM (start/stop/zombie) management.