### PR TITLE
Add prometheus metrics export for P2P

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,7 @@ dependencies = [
  "uuid",
  "vergen",
  "vsock",
+ "zstd",
 ]
 
 [[package]]
@@ -4684,3 +4685,31 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zstd"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.10+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -57,6 +57,7 @@ tonic = { version = "0.8.3", optional = true }
 tower = { version = "0.4.0", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 vsock = { version = "0.3.0", optional = true }
+zstd = { version = "0.13", optional = true }
 
 [features]
 default = ["node-binary"]
@@ -90,6 +91,7 @@ node-binary = [
   "tower",
   "tracing-subscriber",
   "vsock",
+  "zstd",
 ]
 
 [[bin]]

--- a/crates/node/src/networking/p2p/pea2pea.rs
+++ b/crates/node/src/networking/p2p/pea2pea.rs
@@ -205,7 +205,7 @@ impl P2P {
             }
 
             protocol::internal::DiagnosticsRequestKind::Metrics => {
-                let data = metrics::export_metrics();
+                let data = tokio::task::spawn_blocking(move || metrics::export_metrics()).await?;
                 protocol::internal::Message::DiagnosticsResponse(
                     self.public_node_key,
                     protocol::internal::DiagnosticsResponse::Metrics(data),

--- a/crates/node/src/networking/p2p/pea2pea.rs
+++ b/crates/node/src/networking/p2p/pea2pea.rs
@@ -205,7 +205,7 @@ impl P2P {
             }
 
             protocol::internal::DiagnosticsRequestKind::Metrics => {
-                let data = tokio::task::spawn_blocking(move || metrics::export_metrics()).await?;
+                let data = tokio::task::spawn_blocking(metrics::export_metrics).await?;
                 protocol::internal::Message::DiagnosticsResponse(
                     self.public_node_key,
                     protocol::internal::DiagnosticsResponse::Metrics(data),


### PR DESCRIPTION
This change adds support for prometheus metrics export via P2P protocol. Metrics are exported with `TextEncoder` and compressed with `zstd` on default compression level (`3` at the implementation time).