### PR TITLE
Add the ability to join networks to "seed mode" so that we can run a seed cluster

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 crates/tests/e2e-tests/files
 crates/tests/e2e-tests/prover
 crates/tests/e2e-tests/verifier
+.direnv/

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -230,6 +230,14 @@ pub struct P2PBeaconConfig {
     default_value = "127.0.0.1:8888"
     )]
     pub http_healthcheck_listen_addr: SocketAddr,
+
+    #[arg(
+    long,
+    long_help = "Cluster join attempt limit",
+    env = "GEVULOT_CLUSTER_JOIN_ATTEMPT_LIMIT",
+    default_value = "10"
+    )]
+    pub cluster_join_attempt_limit: u16,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -14,7 +14,7 @@ pub struct Config {
     #[arg(
         long,
         long_help = "Directory where the node should store its data",
-        env = "GEVULOT_DATA_DIRECTORY", 
+        env = "GEVULOT_DATA_DIRECTORY",
         default_value_os_t = PathBuf::from("/var/lib/gevulot"),
     )]
     pub data_directory: PathBuf,
@@ -38,7 +38,7 @@ pub struct Config {
     #[arg(
         long,
         long_help = "Directory where the node should store logs",
-        env = "GEVULOT_LOG_DIRECTORY", 
+        env = "GEVULOT_LOG_DIRECTORY",
         default_value_os_t = PathBuf::from("/var/lib/gevulot/log"),
     )]
     pub log_directory: PathBuf,
@@ -180,7 +180,7 @@ pub struct P2PBeaconConfig {
     #[arg(
         long,
         long_help = "Directory where the node should store its data",
-        env = "GEVULOT_DATA_DIRECTORY", 
+        env = "GEVULOT_DATA_DIRECTORY",
         default_value_os_t = PathBuf::from("/var/lib/gevulot"),
     )]
     pub data_directory: PathBuf,
@@ -214,6 +214,14 @@ pub struct P2PBeaconConfig {
         default_value = "9995"
     )]
     pub http_download_port: u16,
+
+    #[arg(
+        long,
+        long_help = "",
+        value_delimiter = ',',
+        env = "GEVULOT_P2P_DISCOVERY_ADDR"
+    )]
+    pub p2p_discovery_addrs: Vec<String>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -222,6 +222,14 @@ pub struct P2PBeaconConfig {
         env = "GEVULOT_P2P_DISCOVERY_ADDR"
     )]
     pub p2p_discovery_addrs: Vec<String>,
+
+    #[arg(
+    long,
+    long_help = "Healthcheck listen address",
+    env = "GEVULOT_HEALTHCHECK_LISTEN_ADDR",
+    default_value = "127.0.0.1:8888"
+    )]
+    pub http_healthcheck_listen_addr: SocketAddr,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -373,7 +373,7 @@ async fn p2p_beacon(config: P2PBeaconConfig) -> Result<()> {
             match addr.to_socket_addrs() {
                 Ok(mut socket_iter) => {
                     if let Some(peer) = socket_iter.next() {
-                        let (connected, fail) = p2p.connect(peer).await;
+                        let (connected, fail) = p2p.do_connect(peer, true).await;
                         connected_nodes += connected.len();
                         if !fail.is_empty() {
                             tracing::info!("Peer connection, fail to connect to these peers:{fail:?}");

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -367,7 +367,7 @@ async fn p2p_beacon(config: P2PBeaconConfig) -> Result<()> {
     let mut connected_nodes = 0;
     let mut try_count = 0;
 
-    while connected_nodes == 0 && try_count < 5 {
+    while connected_nodes == 0 && try_count < config.cluster_join_attempt_limit {
         for addr in config.p2p_discovery_addrs.clone() {
             tracing::info!("connecting to p2p peer {}", addr);
             match addr.to_socket_addrs() {

--- a/crates/node/src/networking/p2p/pea2pea.rs
+++ b/crates/node/src/networking/p2p/pea2pea.rs
@@ -227,7 +227,7 @@ impl P2P {
     // Connect to peer at `addr`. Subsequent connections to newly discovered nodes are done in sequence, one at a time.
     // Peer can be fail because they was 2 simultaneous connection. One is fail and the orher is ok.
     pub async fn connect(&self, addr: SocketAddr) -> (BTreeSet<SocketAddr>, BTreeSet<SocketAddr>) {
-        self.do_connect(addr, false)
+        self.do_connect(addr, false).await
     }
     pub async fn do_connect(&self, addr: SocketAddr, squelch_error: bool) -> (BTreeSet<SocketAddr>, BTreeSet<SocketAddr>) {
         let mut connected_peers = BTreeSet::new();

--- a/crates/node/src/networking/p2p/pea2pea.rs
+++ b/crates/node/src/networking/p2p/pea2pea.rs
@@ -72,7 +72,7 @@ impl P2P {
         nat_listen_addr: Option<SocketAddr>,
         peer_http_port_list: Arc<tokio::sync::RwLock<HashMap<SocketAddr, Option<u16>>>>,
         tx_sender: TxEventSender<P2pSender>,
-        propagate_tx_stream: impl Stream<Item = Transaction<Validated>> + std::marker::Send + 'static,
+        propagate_tx_stream: impl Stream<Item=Transaction<Validated>> + std::marker::Send + 'static,
         node_resources: (u64, u64, u64),
     ) -> Self {
         let config = Config {
@@ -227,6 +227,9 @@ impl P2P {
     // Connect to peer at `addr`. Subsequent connections to newly discovered nodes are done in sequence, one at a time.
     // Peer can be fail because they was 2 simultaneous connection. One is fail and the orher is ok.
     pub async fn connect(&self, addr: SocketAddr) -> (BTreeSet<SocketAddr>, BTreeSet<SocketAddr>) {
+        self.do_connect(addr, false)
+    }
+    pub async fn do_connect(&self, addr: SocketAddr, squelch_error: bool) -> (BTreeSet<SocketAddr>, BTreeSet<SocketAddr>) {
         let mut connected_peers = BTreeSet::new();
         let mut failed_peers = BTreeSet::new();
         let mut peer_to_connect_list = vec![addr];
@@ -246,7 +249,9 @@ impl P2P {
                     self.peer_list.write().await.insert(addr);
                 }
                 Err(err) => {
-                    tracing::error!("An error occurs during peer:{addr} connection: {err}",);
+                    if !squelch_error {
+                        tracing::error!("An error occurs during peer:{addr} connection: {err}",);
+                    }
                     failed_peers.insert(addr);
                 }
             };
@@ -294,9 +299,9 @@ impl Handshake for P2P {
                 let handshake_msg_bytes = protocol::serialize_handshake(
                     self.build_handshake_msg().await,
                 )
-                .map_err(|err| {
-                    std::io::Error::new(std::io::ErrorKind::Other, format!("serialize error:{err}"))
-                })?;
+                    .map_err(|err| {
+                        std::io::Error::new(std::io::ErrorKind::Other, format!("serialize error:{err}"))
+                    })?;
                 stream.write_u32(handshake_msg_bytes.len() as u32).await?;
                 stream.write_all(&handshake_msg_bytes).await?;
 
@@ -337,9 +342,9 @@ impl Handshake for P2P {
                 let handshake_msg_bytes = protocol::serialize_handshake(
                     self.build_handshake_msg().await,
                 )
-                .map_err(|err| {
-                    std::io::Error::new(std::io::ErrorKind::Other, format!("serialize error:{err}"))
-                })?;
+                    .map_err(|err| {
+                        std::io::Error::new(std::io::ErrorKind::Other, format!("serialize error:{err}"))
+                    })?;
                 stream.write_u32(handshake_msg_bytes.len() as u32).await?;
                 stream.write_all(&handshake_msg_bytes).await?;
 
@@ -559,7 +564,7 @@ mod tests {
             p2p_stream1,
             (0, 0, 0),
         )
-        .await;
+            .await;
         (peer, tx_sender, txreceiver1)
     }
 
@@ -593,7 +598,7 @@ mod tests {
             p2p_stream1,
             (0, 0, 0),
         )
-        .await;
+            .await;
         (peer, tx_sender, txreceiver1)
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712439257,
+        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,18 +25,9 @@
                 (p.google-cloud-sdk.withExtraComponents [p.google-cloud-sdk.components.gke-gcloud-auth-plugin])
                 p.k9s
                 p.kube-capacity
-                #p.helix
-                # Language Servers
-                #p.nodePackages_latest.bash-language-server
-                #p.nodePackages_latest.dockerfile-language-server-nodejs
-                #p.terraform-ls
-                #p.nodePackages_latest.vscode-langservers-extracted
-                #p.marksman
-                #p.nil
-                #p.python311Packages.python-lsp-server
-                #p.taplo
-                #p.yaml-language-server
-                #p.ansible-language-server
+                p.openssl
+                p.pkg-config
+                p.protobuf
               ];
             };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Gevulot Stuff";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+
+    # Add dependencies that are only needed for development
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        in
+        {
+          devShells.default = let p = pkgs; in
+            pkgs.mkShell {
+              buildInputs =
+              [
+                p.git
+                p.opentofu
+                p.google-cloud-sdk-gce
+                (p.google-cloud-sdk.withExtraComponents [p.google-cloud-sdk.components.gke-gcloud-auth-plugin])
+                p.k9s
+                p.kube-capacity
+                #p.helix
+                # Language Servers
+                #p.nodePackages_latest.bash-language-server
+                #p.nodePackages_latest.dockerfile-language-server-nodejs
+                #p.terraform-ls
+                #p.nodePackages_latest.vscode-langservers-extracted
+                #p.marksman
+                #p.nil
+                #p.python311Packages.python-lsp-server
+                #p.taplo
+                #p.yaml-language-server
+                #p.ansible-language-server
+              ];
+            };
+        });
+}


### PR DESCRIPTION
To be able to reasonably run this in kubernetes we need to be able to run multiple seed pods.

This change has nodes run in `p2p-beacon` mode to try to join an existing network. This allows us two things.
- Running a seed cluster where there are multiple seed nodes
- Completely shut down the seed nodes being able to start them back up by bootstrapping off an existing network

At start the seed will attempt to contact the nodes listed in the discovery list. After enough attempts instead of failing it will fall back to bootstrapping a brand new network.