### PR TITLE
Just a loop wasn't enough, it goes too fast

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -397,6 +397,8 @@ async fn p2p_beacon(config: P2PBeaconConfig) -> Result<()> {
                     tracing::error!("failed to resolve {}: {}", addr, err);
                 }
             }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
 
         try_count += 1;


### PR DESCRIPTION
Just doing a loop to retry connecting to a potentially existing cluster was very unreliable. The loop goes too fast.

This adds a 1 second delay to the loop so the first pod/service have time to become available for the second one to join.