### PR TITLE
correct cli build on main that fail with async trait error

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+async-trait = { version = "0.1.74" }
 base64 = "0.21.7"
 bincode = "1.3"
 blake3 = "1.5"
@@ -27,7 +28,6 @@ tokio = { version = "1", features = ["full", "io-util", "tracing"] }
 tracing = "0.1"
 uuid = { version = "1", features = [ "v4", "fast-rng", "macro-diagnostics", "serde" ] }
 
-async-trait = { version = "0.1.74", optional = true }
 bytes = { version = "1.5", optional = true }
 clap = { version = "4", features = ["derive", "env", "string"], optional = true }
 console-subscriber = { version = "0.2", optional = true }
@@ -62,7 +62,6 @@ zstd = { version = "0.13", optional = true }
 [features]
 default = ["node-binary"]
 node-binary = [
-  "async-trait",
   "bytes",
   "clap",
   "console-subscriber",


### PR DESCRIPTION
The build of gevulot-cli is bloken on main. We get this error:
```
error[E0432]: unresolved import `async_trait`
 --> crates/node/src/acl/mod.rs:1:5
  |
1 | use async_trait::async_trait;
  |     ^^^^^^^^^^^ use of undeclared crate or module `async_trait`
```
Change async_trait import in gevulot-node cargo.toml.
It works on linux. I didn't test on Mac. I try to test ASAP. I think it should work because async_trait build on Mac. Perhaps @teempai can test?