### PR TITLE
Fix tempfile naming in download manager

### DIFF
--- a/crates/node/src/mempool/txvalidation/download_manager.rs
+++ b/crates/node/src/mempool/txvalidation/download_manager.rs
@@ -96,7 +96,13 @@ pub async fn download_asset_file(
         // This way the file won't be available for download from the other nodes
         // until it is completely written.
         let mut tmp_file_path = file_path.clone();
-        tmp_file_path.set_extension("tmp");
+        match tmp_file_path.extension() {
+            Some(ext) => {
+                tmp_file_path.set_extension(format!("{}.{}", ext.to_string_lossy(), "tmp"))
+            }
+            None => tmp_file_path.set_extension("tmp"),
+        };
+
         let fd = tokio::fs::File::create(&tmp_file_path).await?;
         let mut fd = tokio::io::BufWriter::new(fd);
 


### PR DESCRIPTION
When multiple files with same name, but different extension are submitted for download concurrently, there was a conflict with the filename.

This change fixes by adding ".tmp" to filename instead of replacing the whole extension.