### PR TITLE
fix(shim): remove incorrect path

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -49,7 +49,7 @@ impl Task {
         self.files
             .iter()
             .map(|name| {
-                let path = Path::new(workspace).join(&self.id).join(name);
+                let path = Path::new(workspace).join(name);
                 (name.as_str(), path)
             })
             .collect()


### PR DESCRIPTION

I'm trying to fix the workspace path in the `shim`. Perhaps I'm wrong.

@tuommaki can help to review it when you are free?