### PR TITLE
Don't recovery non-executed txs on startup

### DIFF
--- a/crates/node/src/mempool/mod.rs
+++ b/crates/node/src/mempool/mod.rs
@@ -140,8 +140,7 @@ pub struct Mempool {
 
 impl Mempool {
     pub async fn new(storage: Arc<dyn MempoolStorage>) -> Result<Self> {
-        let mut deque = VecDeque::new();
-        storage.fill_deque(&mut deque).await?;
+        let deque = VecDeque::new();
         Ok(Self { storage, deque })
     }
 


### PR DESCRIPTION
It has turned out in practice that nodes are unable to re-execute old non-executed transactions on startup. It often happens that nodes are running long time without restart and when they do, they start to re-execute transactions from several days / weeks behind, which doesn't make any sense.

Therefore drop the pickup of non-executed transactions on startup and continue from the latest "HEAD".